### PR TITLE
Moe Sync

### DIFF
--- a/java/com/google/turbine/binder/bytecode/BytecodeBinder.java
+++ b/java/com/google/turbine/binder/bytecode/BytecodeBinder.java
@@ -107,14 +107,14 @@ public class BytecodeBinder {
     return Type.ArrayTy.create(bindTy(arrayTySig.elementType(), scope), ImmutableList.of());
   }
 
-  public static Const bindValue(Type type, ElementValue value) {
+  public static Const bindValue(ElementValue value) {
     switch (value.kind()) {
       case ENUM:
         return bindEnumValue((EnumConstValue) value);
       case CONST:
-        return bindConstValue(type, ((ConstValue) value).value());
+        return ((ConstValue) value).value();
       case ARRAY:
-        return bindArrayValue(type, (ArrayValue) value);
+        return bindArrayValue((ArrayValue) value);
       case CLASS:
         return new TurbineClassValue(
             bindTy(
@@ -123,17 +123,16 @@ public class BytecodeBinder {
                   throw new IllegalStateException(x);
                 }));
       case ANNOTATION:
-        return bindAnnotationValue(
-            type, ((ElementValue.ConstTurbineAnnotationValue) value).annotation());
+        return bindAnnotationValue(((ElementValue.ConstTurbineAnnotationValue) value).annotation());
     }
     throw new AssertionError(value.kind());
   }
 
-  static TurbineAnnotationValue bindAnnotationValue(Type type, AnnotationInfo value) {
+  static TurbineAnnotationValue bindAnnotationValue(AnnotationInfo value) {
     ClassSymbol sym = asClassSymbol(value.typeName());
     ImmutableMap.Builder<String, Const> values = ImmutableMap.builder();
     for (Map.Entry<String, ElementValue> e : value.elementValuePairs().entrySet()) {
-      values.put(e.getKey(), bindValue(type, e.getValue()));
+      values.put(e.getKey(), bindValue(e.getValue()));
     }
     return new TurbineAnnotationValue(new AnnoInfo(null, sym, null, values.build()));
   }
@@ -141,7 +140,7 @@ public class BytecodeBinder {
   static ImmutableList<AnnoInfo> bindAnnotations(List<AnnotationInfo> input) {
     ImmutableList.Builder<AnnoInfo> result = ImmutableList.builder();
     for (AnnotationInfo annotation : input) {
-      TurbineAnnotationValue anno = bindAnnotationValue(Type.VOID, annotation);
+      TurbineAnnotationValue anno = bindAnnotationValue(annotation);
       result.add(anno.info());
     }
     return result.build();
@@ -151,10 +150,10 @@ public class BytecodeBinder {
     return new ClassSymbol(s.substring(1, s.length() - 1));
   }
 
-  private static Const bindArrayValue(Type type, ArrayValue value) {
+  private static Const bindArrayValue(ArrayValue value) {
     ImmutableList.Builder<Const> elements = ImmutableList.builder();
     for (ElementValue element : value.elements()) {
-      elements.add(bindValue(type, element));
+      elements.add(bindValue(element));
     }
     return new ArrayInitValue(elements.build());
   }
@@ -163,30 +162,22 @@ public class BytecodeBinder {
     if (type.tyKind() != Type.TyKind.PRIM_TY) {
       return value;
     }
+    // Deficient numberic types and booleans are all stored as ints in the class file,
+    // coerce them to the target type.
     // TODO(b/32626659): this is not bug-compatible with javac
     switch (((Type.PrimTy) type).primkind()) {
       case CHAR:
         return new Const.CharValue(value.asChar().value());
       case SHORT:
         return new Const.ShortValue(value.asShort().value());
-      case INT:
-        return new Const.IntValue(value.asInteger().value());
-      case LONG:
-        return new Const.LongValue(value.asLong().value());
-      case FLOAT:
-        return new Const.FloatValue(value.asFloat().value());
-      case DOUBLE:
-        return new Const.DoubleValue(value.asDouble().value());
       case BOOLEAN:
         // boolean constants are encoded as integers
         return new Const.BooleanValue(value.asInteger().value() != 0);
       case BYTE:
         return new Const.ByteValue(value.asByte().value());
-      case STRING:
-      case NULL:
+      default:
         return value;
     }
-    throw new AssertionError(type);
   }
 
   private static Const bindEnumValue(EnumConstValue value) {

--- a/java/com/google/turbine/binder/bytecode/BytecodeBoundClass.java
+++ b/java/com/google/turbine/binder/bytecode/BytecodeBoundClass.java
@@ -441,7 +441,7 @@ public class BytecodeBoundClass implements BoundClass, HeaderBoundClass, TypeBou
     }
 
     Const defaultValue =
-        m.defaultValue() != null ? BytecodeBinder.bindValue(ret, m.defaultValue()) : null;
+        m.defaultValue() != null ? BytecodeBinder.bindValue(m.defaultValue()) : null;
 
     ImmutableList<AnnoInfo> annotations = BytecodeBinder.bindAnnotations(m.annotations());
 

--- a/java/com/google/turbine/lower/Lower.java
+++ b/java/com/google/turbine/lower/Lower.java
@@ -263,9 +263,9 @@ public class Lower {
 
     ImmutableList<AnnotationInfo> annotations = lowerAnnotations(info.annotations());
 
-    ImmutableList<ClassFile.InnerClass> inners = collectInnerClasses(info.source(), sym, info);
-
     ImmutableList<TypeAnnotationInfo> typeAnnotations = classTypeAnnotations(info);
+
+    ImmutableList<ClassFile.InnerClass> inners = collectInnerClasses(info.source(), sym, info);
 
     ClassFile classfile =
         new ClassFile(

--- a/javatests/com/google/turbine/lower/LowerIntegrationTest.java
+++ b/javatests/com/google/turbine/lower/LowerIntegrationTest.java
@@ -309,6 +309,7 @@ public class LowerIntegrationTest {
       "static_final_boxed.test",
       "anno_void.test",
       "tyanno_varargs.test",
+      "tyanno_inner.test",
     };
     List<Object[]> tests =
         ImmutableList.copyOf(testCases).stream().map(x -> new Object[] {x}).collect(toList());

--- a/javatests/com/google/turbine/lower/testdata/tyanno_inner.test
+++ b/javatests/com/google/turbine/lower/testdata/tyanno_inner.test
@@ -1,0 +1,16 @@
+%%% A.java %%%
+import static java.lang.annotation.ElementType.TYPE_PARAMETER;
+
+import java.lang.annotation.Target;
+
+@interface A {
+
+  @Target(TYPE_PARAMETER)
+  @interface I {
+  }
+}
+
+=== T.java ===
+abstract class T<@A.I X> {
+
+}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix InnerClass attribute computation for type annotations

InnerClasses have to be computed last, to include references to inner
classes from all other attributes (including type annotations).

0b9084fef13d018794f0d654318403114e0662e3

-------

<p> Clean up class reading of deficient numeric and boolean constants

Deficient numeric types (char, byte, short) and booleans are all encoded
as integers in the class file.

Currently the class reader saves an int for all of those types, and we
coerce to the appropriate type during binding by 'target typing'.
However this logic is unnecessary for annotations, since element values
have a local type tag in the class file.

This changes class reading of annotations to immediately convert to the
appropriate type, and saves the legacy 'target typing' to only apply
to fields. We could handle fields during class reading too, but we defer
handling descriptors/signatures to binding for performance reasons.

755b5f98e674cfd1ca784c3e064d12f13b15a644