### PR TITLE
Moe Sync

### DIFF
--- a/java/com/google/turbine/binder/Binder.java
+++ b/java/com/google/turbine/binder/Binder.java
@@ -131,7 +131,7 @@ public class Binder {
     for (ClassSymbol sym : syms) {
       result.put(sym, tenv.get(sym));
     }
-    return new BindingResult(result.build(), boundModules, classPathEnv);
+    return new BindingResult(result.build(), boundModules, classPathEnv, tli);
   }
 
   /** Records enclosing declarations of member classes, and group classes by compilation unit. */
@@ -392,14 +392,17 @@ public class Binder {
     private final ImmutableMap<ClassSymbol, SourceTypeBoundClass> units;
     private final ImmutableList<SourceModuleInfo> modules;
     private final CompoundEnv<ClassSymbol, BytecodeBoundClass> classPathEnv;
+    private final CompoundTopLevelIndex tli;
 
-    public BindingResult(
+    private BindingResult(
         ImmutableMap<ClassSymbol, SourceTypeBoundClass> units,
         ImmutableList<SourceModuleInfo> modules,
-        CompoundEnv<ClassSymbol, BytecodeBoundClass> classPathEnv) {
+        CompoundEnv<ClassSymbol, BytecodeBoundClass> classPathEnv,
+        CompoundTopLevelIndex tli) {
       this.units = units;
       this.modules = modules;
       this.classPathEnv = classPathEnv;
+      this.tli = tli;
     }
 
     /** Bound nodes for sources in the compilation. */
@@ -414,6 +417,10 @@ public class Binder {
     /** The classpath. */
     public CompoundEnv<ClassSymbol, BytecodeBoundClass> classPathEnv() {
       return classPathEnv;
+    }
+
+    public TopLevelIndex tli() {
+      return tli;
     }
   }
 }

--- a/java/com/google/turbine/binder/CompUnitPreprocessor.java
+++ b/java/com/google/turbine/binder/CompUnitPreprocessor.java
@@ -219,6 +219,7 @@ public class CompUnitPreprocessor {
         Optional.empty(),
         ImmutableList.of(),
         ImmutableList.of(),
-        TurbineTyKind.INTERFACE);
+        TurbineTyKind.INTERFACE,
+        /* javadoc= */ null);
   }
 }

--- a/java/com/google/turbine/binder/DisambiguateTypeAnnotations.java
+++ b/java/com/google/turbine/binder/DisambiguateTypeAnnotations.java
@@ -18,10 +18,10 @@ package com.google.turbine.binder;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 
-import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
 import com.google.turbine.binder.bound.SourceTypeBoundClass;
 import com.google.turbine.binder.bound.TurbineAnnotationValue;
 import com.google.turbine.binder.bound.TypeBoundClass;
@@ -241,7 +241,8 @@ public class DisambiguateTypeAnnotations {
    */
   public static ImmutableList<AnnoInfo> groupRepeated(
       Env<ClassSymbol, TypeBoundClass> env, ImmutableList<AnnoInfo> annotations) {
-    Multimap<ClassSymbol, AnnoInfo> repeated = ArrayListMultimap.create();
+    Multimap<ClassSymbol, AnnoInfo> repeated =
+        MultimapBuilder.linkedHashKeys().arrayListValues().build();
     for (AnnoInfo anno : annotations) {
       repeated.put(anno.sym(), anno);
     }

--- a/java/com/google/turbine/binder/bound/TypeBoundClass.java
+++ b/java/com/google/turbine/binder/bound/TypeBoundClass.java
@@ -30,6 +30,8 @@ import com.google.turbine.tree.Tree.MethDecl;
 import com.google.turbine.type.AnnoInfo;
 import com.google.turbine.type.Type;
 import com.google.turbine.type.Type.IntersectionTy;
+import com.google.turbine.type.Type.MethodTy;
+import org.checkerframework.checker.nullness.compatqual.NullableType;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** A bound node that augments {@link HeaderBoundClass} with type information. */
@@ -163,7 +165,7 @@ public interface TypeBoundClass extends HeaderBoundClass {
     private final Const defaultValue;
     private final MethDecl decl;
     private final ImmutableList<AnnoInfo> annotations;
-    private final ParamInfo receiver;
+    private final @NullableType ParamInfo receiver;
 
     public MethodInfo(
         MethodSymbol sym,
@@ -175,7 +177,7 @@ public interface TypeBoundClass extends HeaderBoundClass {
         Const defaultValue,
         MethDecl decl,
         ImmutableList<AnnoInfo> annotations,
-        ParamInfo receiver) {
+        @NullableType ParamInfo receiver) {
       this.sym = sym;
       this.tyParams = tyParams;
       this.returnType = returnType;
@@ -238,9 +240,29 @@ public interface TypeBoundClass extends HeaderBoundClass {
       return annotations;
     }
 
-    /** Receiver parameter. */
-    public ParamInfo receiver() {
+    /** Receiver parameter (see JLS 8.4.1), or {@code null}. */
+    public @NullableType ParamInfo receiver() {
       return receiver;
+    }
+
+    public MethodTy asType() {
+      return MethodTy.create(
+          name(),
+          tyParams.keySet(),
+          returnType,
+          receiver != null ? receiver.type() : null,
+          asTypes(parameters),
+          exceptions);
+    }
+
+    private static ImmutableList<Type> asTypes(ImmutableList<ParamInfo> parameters) {
+      ImmutableList.Builder<Type> result = ImmutableList.builder();
+      for (ParamInfo param : parameters) {
+        if (!param.synthetic()) {
+          result.add(param.type());
+        }
+      }
+      return result.build();
     }
   }
 

--- a/java/com/google/turbine/binder/bound/TypeBoundClass.java
+++ b/java/com/google/turbine/binder/bound/TypeBoundClass.java
@@ -31,7 +31,6 @@ import com.google.turbine.type.AnnoInfo;
 import com.google.turbine.type.Type;
 import com.google.turbine.type.Type.IntersectionTy;
 import com.google.turbine.type.Type.MethodTy;
-import org.checkerframework.checker.nullness.compatqual.NullableType;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** A bound node that augments {@link HeaderBoundClass} with type information. */
@@ -165,7 +164,7 @@ public interface TypeBoundClass extends HeaderBoundClass {
     private final Const defaultValue;
     private final MethDecl decl;
     private final ImmutableList<AnnoInfo> annotations;
-    private final @NullableType ParamInfo receiver;
+    private final @Nullable ParamInfo receiver;
 
     public MethodInfo(
         MethodSymbol sym,
@@ -177,7 +176,7 @@ public interface TypeBoundClass extends HeaderBoundClass {
         Const defaultValue,
         MethDecl decl,
         ImmutableList<AnnoInfo> annotations,
-        @NullableType ParamInfo receiver) {
+        @Nullable ParamInfo receiver) {
       this.sym = sym;
       this.tyParams = tyParams;
       this.returnType = returnType;
@@ -241,7 +240,7 @@ public interface TypeBoundClass extends HeaderBoundClass {
     }
 
     /** Receiver parameter (see JLS 8.4.1), or {@code null}. */
-    public @NullableType ParamInfo receiver() {
+    public @Nullable ParamInfo receiver() {
       return receiver;
     }
 

--- a/java/com/google/turbine/binder/sym/ClassSymbol.java
+++ b/java/com/google/turbine/binder/sym/ClassSymbol.java
@@ -33,6 +33,16 @@ public class ClassSymbol implements Symbol {
   public static final ClassSymbol STRING = new ClassSymbol("java/lang/String");
   public static final ClassSymbol ENUM = new ClassSymbol("java/lang/Enum");
   public static final ClassSymbol ANNOTATION = new ClassSymbol("java/lang/annotation/Annotation");
+  public static final ClassSymbol ERROR = new ClassSymbol("<error>");
+
+  public static final ClassSymbol CHARACTER = new ClassSymbol("java/lang/Character");
+  public static final ClassSymbol SHORT = new ClassSymbol("java/lang/Short");
+  public static final ClassSymbol INTEGER = new ClassSymbol("java/lang/Integer");
+  public static final ClassSymbol LONG = new ClassSymbol("java/lang/Long");
+  public static final ClassSymbol FLOAT = new ClassSymbol("java/lang/Float");
+  public static final ClassSymbol DOUBLE = new ClassSymbol("java/lang/Double");
+  public static final ClassSymbol BOOLEAN = new ClassSymbol("java/lang/Boolean");
+  public static final ClassSymbol BYTE = new ClassSymbol("java/lang/Byte");
 
   private final String className;
 

--- a/java/com/google/turbine/model/Const.java
+++ b/java/com/google/turbine/model/Const.java
@@ -18,6 +18,7 @@ package com.google.turbine.model;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.escape.SourceCodeEscapers;
 
 /**
  * Compile-time constant expressions, including literals of primitive or String type, class
@@ -299,30 +300,7 @@ public abstract class Const {
 
     @Override
     public String toString() {
-      return '\'' + escape(value) + '\'';
-    }
-
-    private static String escape(char value) {
-      switch (value) {
-        case '\b':
-          return "\\b";
-        case '\f':
-          return "\\f";
-        case '\n':
-          return "\\n";
-        case '\r':
-          return "\\r";
-        case '\t':
-          return "\\t";
-        case '"':
-          return "\\\"";
-        case '\\':
-          return "\\\\";
-        case '\'':
-          return "\\'";
-        default:
-          return String.valueOf(value);
-      }
+      return "'" + SourceCodeEscapers.javaCharEscaper().escape(String.valueOf(value)) + "'";
     }
 
     @Override
@@ -541,7 +519,7 @@ public abstract class Const {
 
     @Override
     public String toString() {
-      return String.format("\"%s\"", value);
+      return '"' + SourceCodeEscapers.javaCharEscaper().escape(value) + '"';
     }
 
     @Override
@@ -579,7 +557,7 @@ public abstract class Const {
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+      return String.format("(short)%d", value);
     }
 
     @Override
@@ -712,7 +690,7 @@ public abstract class Const {
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+      return String.format("(byte)0x%02x", value);
     }
   }
 

--- a/java/com/google/turbine/parse/IteratorLexer.java
+++ b/java/com/google/turbine/parse/IteratorLexer.java
@@ -59,4 +59,9 @@ public class IteratorLexer implements Lexer {
     // TODO(cushon): test expression position EOF handling
     return curr != null ? curr.position : -1;
   }
+
+  @Override
+  public String javadoc() {
+    return null;
+  }
 }

--- a/java/com/google/turbine/parse/Lexer.java
+++ b/java/com/google/turbine/parse/Lexer.java
@@ -31,4 +31,7 @@ public interface Lexer {
 
   /** Returns the source file for diagnostics. */
   SourceFile source();
+
+  /** Returns a saved javadoc comment. */
+  String javadoc();
 }

--- a/java/com/google/turbine/parse/Parser.java
+++ b/java/com/google/turbine/parse/Parser.java
@@ -215,6 +215,7 @@ public class Parser {
   }
 
   private TyDecl interfaceDeclaration(EnumSet<TurbineModifier> access, ImmutableList<Anno> annos) {
+    String javadoc = lexer.javadoc();
     eat(Token.INTERFACE);
     int pos = position;
     Ident name = eatIdent();
@@ -243,10 +244,12 @@ public class Parser {
         Optional.<ClassTy>empty(),
         interfaces.build(),
         members,
-        TurbineTyKind.INTERFACE);
+        TurbineTyKind.INTERFACE,
+        javadoc);
   }
 
   private TyDecl annotationDeclaration(EnumSet<TurbineModifier> access, ImmutableList<Anno> annos) {
+    String javadoc = lexer.javadoc();
     eat(Token.INTERFACE);
     int pos = position;
     Ident name = eatIdent();
@@ -262,10 +265,12 @@ public class Parser {
         Optional.<ClassTy>empty(),
         ImmutableList.<ClassTy>of(),
         members,
-        TurbineTyKind.ANNOTATION);
+        TurbineTyKind.ANNOTATION,
+        javadoc);
   }
 
   private TyDecl enumDeclaration(EnumSet<TurbineModifier> access, ImmutableList<Anno> annos) {
+    String javadoc = lexer.javadoc();
     eat(Token.ENUM);
     int pos = position;
     Ident name = eatIdent();
@@ -289,7 +294,8 @@ public class Parser {
         Optional.<ClassTy>empty(),
         interfaces.build(),
         members,
-        TurbineTyKind.ENUM);
+        TurbineTyKind.ENUM,
+        javadoc);
   }
 
   private String moduleName() {
@@ -468,7 +474,8 @@ public class Parser {
                         ImmutableList.<Type>of(),
                         ImmutableList.of()),
                     name,
-                    Optional.<Expression>empty()));
+                    Optional.<Expression>empty(),
+                    null));
             annos = ImmutableList.builder();
             break;
           }
@@ -491,6 +498,7 @@ public class Parser {
   }
 
   private TyDecl classDeclaration(EnumSet<TurbineModifier> access, ImmutableList<Anno> annos) {
+    String javadoc = lexer.javadoc();
     eat(Token.CLASS);
     int pos = position;
     Ident name = eatIdent();
@@ -522,7 +530,8 @@ public class Parser {
         Optional.ofNullable(xtnds),
         interfaces.build(),
         members,
-        TurbineTyKind.CLASS);
+        TurbineTyKind.CLASS,
+        javadoc);
   }
 
   private ImmutableList<Tree> classMembers() {
@@ -809,6 +818,7 @@ public class Parser {
       ImmutableList<Anno> annos,
       Type baseTy,
       Ident name) {
+    String javadoc = lexer.javadoc();
     ImmutableList.Builder<Tree> result = ImmutableList.builder();
     VariableInitializerParser initializerParser = new VariableInitializerParser(token, lexer);
     List<List<SavedToken>> bits = initializerParser.parseInitializers();
@@ -833,7 +843,7 @@ public class Parser {
       if (init != null && init.kind() == Tree.Kind.ARRAY_INIT) {
         init = null;
       }
-      result.add(new VarDecl(pos, access, annos, ty, name, Optional.ofNullable(init)));
+      result.add(new VarDecl(pos, access, annos, ty, name, Optional.ofNullable(init), javadoc));
     }
     if (token != SEMI) {
       throw TurbineError.format(lexer.source(), expressionStart, ErrorKind.UNTERMINATED_EXPRESSION);
@@ -849,6 +859,7 @@ public class Parser {
       ImmutableList<TyParam> typaram,
       Type result,
       Ident name) {
+    String javadoc = lexer.javadoc();
     eat(Token.LPAREN);
     ImmutableList.Builder<VarDecl> formals = ImmutableList.builder();
     formalParams(formals, access);
@@ -900,7 +911,8 @@ public class Parser {
         name,
         formals.build(),
         exceptions.build(),
-        Optional.ofNullable(defaultValue));
+        Optional.ofNullable(defaultValue),
+        javadoc);
   }
 
   /**
@@ -995,7 +1007,8 @@ public class Parser {
       name = identOrThis();
     }
     ty = extraDims(ty);
-    return new VarDecl(position, access, annos.build(), ty, name, Optional.<Expression>empty());
+    return new VarDecl(
+        position, access, annos.build(), ty, name, Optional.<Expression>empty(), null);
   }
 
   private Ident identOrThis() {

--- a/java/com/google/turbine/processing/ClassHierarchy.java
+++ b/java/com/google/turbine/processing/ClassHierarchy.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import com.google.common.collect.ImmutableList;
+import com.google.turbine.binder.bound.TypeBoundClass;
+import com.google.turbine.binder.env.Env;
+import com.google.turbine.binder.sym.ClassSymbol;
+import com.google.turbine.type.Type;
+import com.google.turbine.type.Type.ClassTy;
+import com.google.turbine.type.Type.TyKind;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A representation of the class hierarchy, with logic for performing search between subtypes and
+ * their supertypes.
+ */
+public class ClassHierarchy {
+
+  // TODO(cushon): reset between rounds
+  private final Map<ClassSymbol, HierarchyNode> cache = new HashMap<>();
+  private final Env<ClassSymbol, ? extends TypeBoundClass> env;
+
+  ClassHierarchy(Env<ClassSymbol, ? extends TypeBoundClass> env) {
+    this.env = env;
+  }
+
+  /** A linked list between two types in the hierarchy. */
+  private static class PathNode {
+
+    /** The class for this node. */
+    final ClassTy type;
+
+    /** The node corresponding to a direct super-type of this class, or {@code null}. */
+    final PathNode ancestor;
+
+    PathNode(ClassTy type, PathNode ancestor) {
+      this.type = type;
+      this.ancestor = ancestor;
+    }
+  }
+
+  /**
+   * A node in the type hierarchy, corresponding to a class symbol U. For each type V in the
+   * transitive supertype hierarchy of U, we save a mapping from the class symbol for V to the path
+   * from U to V in the type hierarchy.
+   */
+  private class HierarchyNode {
+
+    private final ClassSymbol sym;
+    private final Map<ClassSymbol, PathNode> ancestors = new HashMap<>();
+
+    HierarchyNode(ClassSymbol sym) {
+      this.sym = sym;
+    }
+
+    /** Adds a child (direct supertype) of this node. */
+    private void add(Type type) {
+      if (type.tyKind() != TyKind.CLASS_TY) {
+        // ignore any erroneous types that ended up in the hierarchy
+        return;
+      }
+      ClassTy classTy = (ClassTy) type;
+      HierarchyNode child = get(classTy.sym());
+      // add a new edge to the direct supertype
+      PathNode existing = ancestors.putIfAbsent(child.sym, new PathNode(classTy, null));
+      if (existing != null) {
+        // if this child has already been added don't re-process its ancestors
+        return;
+      }
+      // copy and extend edges for the transitive supertypes
+      for (Map.Entry<ClassSymbol, PathNode> n : child.ancestors.entrySet()) {
+        ancestors.putIfAbsent(n.getKey(), new PathNode(classTy, n.getValue()));
+      }
+    }
+  }
+
+  private HierarchyNode compute(ClassSymbol sym) {
+    HierarchyNode node = new HierarchyNode(sym);
+    TypeBoundClass info = env.get(sym);
+    if (info.superClassType() != null) {
+      node.add(info.superClassType());
+    }
+    for (Type type : info.interfaceTypes()) {
+      node.add(type);
+    }
+    return node;
+  }
+
+  private HierarchyNode get(ClassSymbol sym) {
+    // dont use computeIfAbsent, to support re-entrant lookups
+    HierarchyNode result = cache.get(sym);
+    if (result != null) {
+      return result;
+    }
+    result = compute(sym);
+    cache.put(sym, result);
+    return result;
+  }
+
+  /**
+   * Returns a list of types on the path between the given type {@code t} and a transitive
+   * superclass {@code s}, or an empty list if no such path exists.
+   */
+  ImmutableList<ClassTy> search(Type t, ClassSymbol s) {
+    if (t.tyKind() != TyKind.CLASS_TY) {
+      return ImmutableList.of();
+    }
+    ClassTy classTy = (ClassTy) t;
+    if (classTy.sym().equals(s)) {
+      return ImmutableList.of(classTy);
+    }
+    HierarchyNode node = get(classTy.sym());
+    PathNode path = node.ancestors.get(s);
+    if (path == null) {
+      return ImmutableList.of();
+    }
+    ImmutableList.Builder<ClassTy> result = ImmutableList.builder();
+    result.add(classTy);
+    while (path != null) {
+      result.add(path.type);
+      path = path.ancestor;
+    }
+    return result.build().reverse();
+  }
+}

--- a/java/com/google/turbine/processing/ModelFactory.java
+++ b/java/com/google/turbine/processing/ModelFactory.java
@@ -47,6 +47,7 @@ import com.google.turbine.processing.TurbineElement.TurbineTypeElement;
 import com.google.turbine.processing.TurbineElement.TurbineTypeParameterElement;
 import com.google.turbine.processing.TurbineTypeMirror.TurbineArrayType;
 import com.google.turbine.processing.TurbineTypeMirror.TurbineDeclaredType;
+import com.google.turbine.processing.TurbineTypeMirror.TurbineExecutableType;
 import com.google.turbine.processing.TurbineTypeMirror.TurbineIntersectionType;
 import com.google.turbine.processing.TurbineTypeMirror.TurbineNoType;
 import com.google.turbine.processing.TurbineTypeMirror.TurbinePackageType;
@@ -58,6 +59,7 @@ import com.google.turbine.type.Type;
 import com.google.turbine.type.Type.ArrayTy;
 import com.google.turbine.type.Type.ClassTy;
 import com.google.turbine.type.Type.IntersectionTy;
+import com.google.turbine.type.Type.MethodTy;
 import com.google.turbine.type.Type.PrimTy;
 import com.google.turbine.type.Type.TyVar;
 import com.google.turbine.type.Type.WildTy;
@@ -140,6 +142,8 @@ class ModelFactory {
         return new TurbineIntersectionType(this, intersectionTy);
       case NONE_TY:
         return new TurbineNoType(this);
+      case METHOD_TY:
+        return new TurbineExecutableType(this, (MethodTy) type);
       case ERROR_TY:
     }
     throw new AssertionError(type.tyKind());

--- a/java/com/google/turbine/processing/ModelFactory.java
+++ b/java/com/google/turbine/processing/ModelFactory.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.base.Verify;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.turbine.binder.bound.TypeBoundClass;
+import com.google.turbine.binder.bound.TypeBoundClass.FieldInfo;
+import com.google.turbine.binder.bound.TypeBoundClass.MethodInfo;
+import com.google.turbine.binder.bound.TypeBoundClass.ParamInfo;
+import com.google.turbine.binder.bound.TypeBoundClass.TyVarInfo;
+import com.google.turbine.binder.env.Env;
+import com.google.turbine.binder.sym.ClassSymbol;
+import com.google.turbine.binder.sym.FieldSymbol;
+import com.google.turbine.binder.sym.MethodSymbol;
+import com.google.turbine.binder.sym.PackageSymbol;
+import com.google.turbine.binder.sym.ParamSymbol;
+import com.google.turbine.binder.sym.Symbol;
+import com.google.turbine.binder.sym.TyVarSymbol;
+import com.google.turbine.model.TurbineConstantTypeKind;
+import com.google.turbine.processing.TurbineElement.TurbineExecutableElement;
+import com.google.turbine.processing.TurbineElement.TurbineFieldElement;
+import com.google.turbine.processing.TurbineElement.TurbinePackageElement;
+import com.google.turbine.processing.TurbineElement.TurbineParameterElement;
+import com.google.turbine.processing.TurbineElement.TurbineTypeElement;
+import com.google.turbine.processing.TurbineElement.TurbineTypeParameterElement;
+import com.google.turbine.processing.TurbineTypeMirror.TurbineArrayType;
+import com.google.turbine.processing.TurbineTypeMirror.TurbineDeclaredType;
+import com.google.turbine.processing.TurbineTypeMirror.TurbineIntersectionType;
+import com.google.turbine.processing.TurbineTypeMirror.TurbineNoType;
+import com.google.turbine.processing.TurbineTypeMirror.TurbinePackageType;
+import com.google.turbine.processing.TurbineTypeMirror.TurbinePrimitiveType;
+import com.google.turbine.processing.TurbineTypeMirror.TurbineTypeVariable;
+import com.google.turbine.processing.TurbineTypeMirror.TurbineVoidType;
+import com.google.turbine.processing.TurbineTypeMirror.TurbineWildcardType;
+import com.google.turbine.type.Type;
+import com.google.turbine.type.Type.ArrayTy;
+import com.google.turbine.type.Type.ClassTy;
+import com.google.turbine.type.Type.IntersectionTy;
+import com.google.turbine.type.Type.PrimTy;
+import com.google.turbine.type.Type.TyVar;
+import com.google.turbine.type.Type.WildTy;
+import java.util.HashMap;
+import java.util.Map;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.NoType;
+import javax.lang.model.type.TypeMirror;
+
+/**
+ * A factoy for turbine's implementations of {@link Element} and {@link TypeMirror}.
+ *
+ * <p>The model provided by those interfaces contains cycles between types and elements, e.g. {@link
+ * Element#asType} and {@link DeclaredType#asElement}. Turbine's internal model uses an immutable
+ * representation of classes and types which cannot represent cycles directly. Instead, the
+ * implementations in {@link TurbineElement} and {@link TurbineTypeMirror} maintain a reference to
+ * this class, and use it to lazily construct edges in the type and element graph.
+ */
+class ModelFactory {
+
+  private final Env<ClassSymbol, ? extends TypeBoundClass> env;
+
+  private final HashMap<Type, TurbineTypeMirror> typeCache = new HashMap<>();
+
+  private final Map<FieldSymbol, TurbineFieldElement> fieldCache = new HashMap<>();
+  private final Map<MethodSymbol, TurbineExecutableElement> methodCache = new HashMap<>();
+  private final Map<ClassSymbol, TurbineTypeElement> classCache = new HashMap<>();
+  private final Map<ParamSymbol, TurbineParameterElement> paramCache = new HashMap<>();
+  private final Map<TyVarSymbol, TurbineTypeParameterElement> tyParamCache = new HashMap<>();
+  private final Map<PackageSymbol, TurbinePackageElement> packageCache = new HashMap<>();
+
+  ModelFactory(Env<ClassSymbol, ? extends TypeBoundClass> env) {
+    this.env = env;
+  }
+
+  TypeMirror asTypeMirror(Type type) {
+    return typeCache.computeIfAbsent(type, this::createTypeMirror);
+  }
+
+  /**
+   * Returns a supplier that memoizes the result of the input supplier.
+   *
+   * <p>It ensures that the results are invalidated after each annotation processing round, to
+   * support computations that depend on information in the current round and which might change in
+   * future, e.g. as additional types are generated.
+   */
+  <T> Supplier<T> memoize(Supplier<T> s) {
+    // TODO(cushon): reset cached state between rounds
+    return Suppliers.memoize(s);
+  }
+
+  /** Creates a {@link TurbineTypeMirror} backed by a {@link Type}. */
+  private TurbineTypeMirror createTypeMirror(Type type) {
+    switch (type.tyKind()) {
+      case PRIM_TY:
+        if (((PrimTy) type).primkind() == TurbineConstantTypeKind.STRING) {
+          return new TurbineDeclaredType(this, ClassTy.STRING);
+        }
+        return new TurbinePrimitiveType(this, (PrimTy) type);
+      case CLASS_TY:
+        return new TurbineDeclaredType(this, (ClassTy) type);
+      case ARRAY_TY:
+        return new TurbineArrayType(this, (ArrayTy) type);
+      case VOID_TY:
+        return new TurbineVoidType(this);
+      case WILD_TY:
+        return new TurbineWildcardType(this, (WildTy) type);
+      case TY_VAR:
+        return new TurbineTypeVariable(this, (TyVar) type);
+      case INTERSECTION_TY:
+        return new TurbineIntersectionType(this, (IntersectionTy) type);
+      case ERROR_TY:
+    }
+    throw new AssertionError(type.tyKind());
+  }
+
+  /** Creates a list of {@link TurbineTypeMirror}s backed by the given {@link Type}s. */
+  ImmutableList<TypeMirror> asTypeMirrors(ImmutableList<? extends Type> types) {
+    ImmutableList.Builder<TypeMirror> result = ImmutableList.builder();
+    for (Type type : types) {
+      result.add(asTypeMirror(type));
+    }
+    return result.build();
+  }
+
+  NoType noType() {
+    return new TurbineNoType(this);
+  }
+
+  NoType packageType(PackageSymbol symbol) {
+    return new TurbinePackageType(this, symbol);
+  }
+
+  /** Creates an {@link Element} backed by the given {@link Symbol}. */
+  Element element(Symbol symbol) {
+    switch (symbol.symKind()) {
+      case CLASS:
+        return typeElement((ClassSymbol) symbol);
+      case TY_PARAM:
+        return typeParameterElement((TyVarSymbol) symbol);
+      case METHOD:
+        return executableElement((MethodSymbol) symbol);
+      case FIELD:
+        return fieldElement((FieldSymbol) symbol);
+      case PARAMETER:
+        return parameterElement((ParamSymbol) symbol);
+      case PACKAGE:
+        return packageElement((PackageSymbol) symbol);
+      case MODULE:
+        break;
+    }
+    throw new AssertionError(symbol.symKind());
+  }
+
+  TurbineFieldElement fieldElement(FieldSymbol symbol) {
+    return fieldCache.computeIfAbsent(symbol, k -> new TurbineFieldElement(this, symbol));
+  }
+
+  TurbineExecutableElement executableElement(MethodSymbol symbol) {
+    return methodCache.computeIfAbsent(symbol, k -> new TurbineExecutableElement(this, symbol));
+  }
+
+  TurbineTypeElement typeElement(ClassSymbol symbol) {
+    Verify.verify(!symbol.simpleName().equals("package-info"), "%s", symbol);
+    return classCache.computeIfAbsent(symbol, k -> new TurbineTypeElement(this, symbol));
+  }
+
+  TurbinePackageElement packageElement(PackageSymbol symbol) {
+    return packageCache.computeIfAbsent(symbol, k -> new TurbinePackageElement(this, symbol));
+  }
+
+  VariableElement parameterElement(ParamSymbol sym) {
+    return paramCache.computeIfAbsent(sym, k -> new TurbineParameterElement(this, sym));
+  }
+
+  TurbineTypeParameterElement typeParameterElement(TyVarSymbol sym) {
+    return tyParamCache.computeIfAbsent(sym, k -> new TurbineTypeParameterElement(this, sym));
+  }
+
+  ImmutableSet<Element> elements(ImmutableSet<? extends Symbol> symbols) {
+    ImmutableSet.Builder<Element> result = ImmutableSet.builder();
+    for (Symbol symbol : symbols) {
+      result.add(element(symbol));
+    }
+    return result.build();
+  }
+
+  /**
+   * Returns the {@link TypeBoundClass} for the given {@link ClassSymbol} from the current
+   * environment.
+   */
+  TypeBoundClass getSymbol(ClassSymbol sym) {
+    return env.get(sym);
+  }
+
+  MethodInfo getMethodInfo(MethodSymbol method) {
+    TypeBoundClass info = getSymbol(method.owner());
+    for (MethodInfo m : info.methods()) {
+      if (m.sym().equals(method)) {
+        return m;
+      }
+    }
+    return null;
+  }
+
+  ParamInfo getParamInfo(ParamSymbol sym) {
+    MethodInfo info = getMethodInfo(sym.owner());
+    for (ParamInfo p : info.parameters()) {
+      if (p.sym().equals(sym)) {
+        return p;
+      }
+    }
+    return null;
+  }
+
+  FieldInfo getFieldInfo(FieldSymbol symbol) {
+    TypeBoundClass info = getSymbol(symbol.owner());
+    requireNonNull(info, symbol.owner().toString());
+    for (FieldInfo field : info.fields()) {
+      if (field.sym().equals(symbol)) {
+        return field;
+      }
+    }
+    throw new AssertionError(symbol);
+  }
+
+  TyVarInfo getTyVarInfo(TyVarSymbol tyVar) {
+    Symbol owner = tyVar.owner();
+    Verify.verifyNotNull(owner); // TODO(cushon): capture variables
+    ImmutableMap<TyVarSymbol, TyVarInfo> tyParams;
+    switch (owner.symKind()) {
+      case METHOD:
+        tyParams = getMethodInfo((MethodSymbol) owner).tyParams();
+        break;
+      case CLASS:
+        tyParams = getSymbol((ClassSymbol) owner).typeParameterTypes();
+        break;
+      default:
+        throw new AssertionError(owner.symKind());
+    }
+    return tyParams.get(tyVar);
+  }
+}

--- a/java/com/google/turbine/processing/TurbineElement.java
+++ b/java/com/google/turbine/processing/TurbineElement.java
@@ -1,0 +1,903 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
+import com.google.turbine.binder.bound.TypeBoundClass;
+import com.google.turbine.binder.bound.TypeBoundClass.FieldInfo;
+import com.google.turbine.binder.bound.TypeBoundClass.MethodInfo;
+import com.google.turbine.binder.bound.TypeBoundClass.ParamInfo;
+import com.google.turbine.binder.bound.TypeBoundClass.TyVarInfo;
+import com.google.turbine.binder.sym.ClassSymbol;
+import com.google.turbine.binder.sym.FieldSymbol;
+import com.google.turbine.binder.sym.MethodSymbol;
+import com.google.turbine.binder.sym.PackageSymbol;
+import com.google.turbine.binder.sym.ParamSymbol;
+import com.google.turbine.binder.sym.Symbol;
+import com.google.turbine.binder.sym.TyVarSymbol;
+import com.google.turbine.model.TurbineFlag;
+import com.google.turbine.model.TurbineTyKind;
+import com.google.turbine.type.Type;
+import com.google.turbine.type.Type.ClassTy;
+import com.google.turbine.type.Type.ClassTy.SimpleClassTy;
+import java.lang.annotation.Annotation;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ElementVisitor;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.NestingKind;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeMirror;
+
+/** An {@link Element} implementation backed by a {@link Symbol}. */
+public abstract class TurbineElement implements Element {
+
+  @Override
+  public abstract int hashCode();
+
+  @Override
+  public abstract boolean equals(Object obj);
+
+  protected final ModelFactory factory;
+
+  protected <T> Supplier<T> memoize(Supplier<T> supplier) {
+    return factory.memoize(supplier);
+  }
+
+  protected TurbineElement(ModelFactory factory) {
+    this.factory = requireNonNull(factory);
+  }
+
+  @Override
+  public <A extends Annotation> A getAnnotation(Class<A> annotationType) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public final <A extends Annotation> A[] getAnnotationsByType(Class<A> annotationType) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public final List<? extends AnnotationMirror> getAnnotationMirrors() {
+    throw new UnsupportedOperationException();
+  }
+
+  /** A {@link TypeElement} implementation backed by a {@link ClassSymbol}. */
+  static class TurbineTypeElement extends TurbineElement implements TypeElement {
+
+    @Override
+    public int hashCode() {
+      return symbol.hashCode();
+    }
+
+    private final ClassSymbol symbol;
+    private final Supplier<TypeBoundClass> info;
+
+    TurbineTypeElement(ModelFactory factory, ClassSymbol symbol) {
+      super(factory);
+      requireNonNull(factory);
+      requireNonNull(symbol);
+      this.symbol = symbol;
+      this.info =
+          memoize(
+              new Supplier<TypeBoundClass>() {
+                @Override
+                public TypeBoundClass get() {
+                  return factory.getSymbol(symbol);
+                }
+              });
+    }
+
+    private TypeBoundClass info() {
+      return info.get();
+    }
+
+    @Override
+    public NestingKind getNestingKind() {
+      TypeBoundClass info = info();
+      return (info != null && info.owner() != null) ? NestingKind.MEMBER : NestingKind.TOP_LEVEL;
+    }
+
+    private final Supplier<TurbineName> qualifiedName =
+        memoize(
+            new Supplier<TurbineName>() {
+              @Override
+              public TurbineName get() {
+                TypeBoundClass info = info();
+                if (info == null || info.owner() == null) {
+                  return new TurbineName(symbol.toString());
+                }
+                ClassSymbol sym = sym();
+                Deque<String> flat = new ArrayDeque<>();
+                while (info.owner() != null) {
+                  flat.addFirst(sym.binaryName().substring(info.owner().binaryName().length() + 1));
+                  sym = info.owner();
+                  info = factory.getSymbol(sym);
+                }
+                flat.addFirst(sym.toString());
+                return new TurbineName(Joiner.on('.').join(flat));
+              }
+            });
+
+    @Override
+    public Name getQualifiedName() {
+      return qualifiedName.get();
+    }
+
+    private final Supplier<TypeMirror> superClass =
+        memoize(
+            new Supplier<TypeMirror>() {
+              @Override
+              public TypeMirror get() {
+                TypeBoundClass info = info();
+                switch (info.kind()) {
+                  case CLASS:
+                    if (info.superclass() != null) {
+                      return factory.asTypeMirror(info.superClassType());
+                    }
+                    return factory.noType();
+                  case ENUM:
+                  case INTERFACE:
+                  case ANNOTATION:
+                    return factory.noType();
+                }
+                throw new AssertionError(info.kind());
+              }
+            });
+
+    @Override
+    public TypeMirror getSuperclass() {
+      return superClass.get();
+    }
+
+    @Override
+    public String toString() {
+      return getQualifiedName().toString();
+    }
+
+    private final Supplier<List<TypeMirror>> interfaces =
+        memoize(
+            new Supplier<List<TypeMirror>>() {
+              @Override
+              public List<TypeMirror> get() {
+                return factory.asTypeMirrors(info().interfaceTypes());
+              }
+            });
+
+    @Override
+    public List<? extends TypeMirror> getInterfaces() {
+      return interfaces.get();
+    }
+
+    private final Supplier<ImmutableList<TypeParameterElement>> typeParameters =
+        memoize(
+            new Supplier<ImmutableList<TypeParameterElement>>() {
+              @Override
+              public ImmutableList<TypeParameterElement> get() {
+                ImmutableList.Builder<TypeParameterElement> result = ImmutableList.builder();
+                for (TyVarSymbol p : info().typeParameters().values()) {
+                  result.add(factory.typeParameterElement(p));
+                }
+                return result.build();
+              }
+            });
+
+    @Override
+    public List<? extends TypeParameterElement> getTypeParameters() {
+      return typeParameters.get();
+    }
+
+    private final Supplier<TypeMirror> type =
+        memoize(
+            new Supplier<TypeMirror>() {
+              @Override
+              public TypeMirror get() {
+                return factory.asTypeMirror(asGenericType(symbol));
+              }
+
+              ClassTy asGenericType(ClassSymbol symbol) {
+                TypeBoundClass info = info();
+                if (info == null) {
+                  return ClassTy.asNonParametricClassTy(symbol);
+                }
+                Deque<Type.ClassTy.SimpleClassTy> simples = new ArrayDeque<>();
+                simples.addFirst(simple(symbol, info));
+                while (info.owner() != null && (info.access() & TurbineFlag.ACC_STATIC) == 0) {
+                  symbol = info.owner();
+                  info = factory.getSymbol(symbol);
+                  simples.addFirst(simple(symbol, info));
+                }
+                return ClassTy.create(ImmutableList.copyOf(simples));
+              }
+
+              private SimpleClassTy simple(ClassSymbol sym, TypeBoundClass info) {
+                ImmutableList.Builder<Type> args = ImmutableList.builder();
+                for (TyVarSymbol t : info.typeParameters().values()) {
+                  args.add(Type.TyVar.create(t, ImmutableList.of()));
+                }
+                return SimpleClassTy.create(sym, args.build(), ImmutableList.of());
+              }
+            });
+
+    @Override
+    public TypeMirror asType() {
+      return type.get();
+    }
+
+    @Override
+    public ElementKind getKind() {
+      TypeBoundClass info = info();
+      switch (info.kind()) {
+        case CLASS:
+          return ElementKind.CLASS;
+        case INTERFACE:
+          return ElementKind.INTERFACE;
+        case ENUM:
+          return ElementKind.ENUM;
+        case ANNOTATION:
+          return ElementKind.ANNOTATION_TYPE;
+      }
+      throw new AssertionError(info.kind());
+    }
+
+    @Override
+    public Set<Modifier> getModifiers() {
+      return asModifierSet(ModifierOwner.TYPE, info().access() & ~TurbineFlag.ACC_SUPER);
+    }
+
+    private final Supplier<TurbineName> simpleName =
+        memoize(
+            new Supplier<TurbineName>() {
+              @Override
+              public TurbineName get() {
+                TypeBoundClass info = info();
+                if (info == null || info.owner() == null) {
+                  return new TurbineName(symbol.simpleName());
+                }
+                return new TurbineName(
+                    symbol.binaryName().substring(info.owner().binaryName().length() + 1));
+              }
+            });
+
+    @Override
+    public Name getSimpleName() {
+      return simpleName.get();
+    }
+
+    private final Supplier<Element> enclosing =
+        memoize(
+            new Supplier<Element>() {
+              @Override
+              public Element get() {
+                TypeBoundClass info = info();
+                if (info != null && info.owner() != null) {
+                  return factory.typeElement(info.owner());
+                }
+                return factory.packageElement(symbol.owner());
+              }
+            });
+
+    @Override
+    public Element getEnclosingElement() {
+      return enclosing.get();
+    }
+
+    private final Supplier<ImmutableList<Element>> enclosed =
+        memoize(
+            new Supplier<ImmutableList<Element>>() {
+              @Override
+              public ImmutableList<Element> get() {
+                TypeBoundClass info = info();
+                ImmutableList.Builder<Element> result = ImmutableList.builder();
+                for (FieldInfo field : info.fields()) {
+                  result.add(factory.fieldElement(field.sym()));
+                }
+                for (MethodInfo method : info.methods()) {
+                  result.add(factory.executableElement(method.sym()));
+                }
+                for (ClassSymbol child : info.children().values()) {
+                  result.add(factory.typeElement(child));
+                }
+                return result.build();
+              }
+            });
+
+    @Override
+    public List<? extends Element> getEnclosedElements() {
+      return enclosed.get();
+    }
+
+    @Override
+    public <R, P> R accept(ElementVisitor<R, P> v, P p) {
+      return v.visitType(this, p);
+    }
+
+    public ClassSymbol sym() {
+      return symbol;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj instanceof TurbineTypeElement && symbol.equals(((TurbineTypeElement) obj).symbol);
+    }
+  }
+
+  /** A {@link TypeParameterElement} implementation backed by a {@link TyVarSymbol}. */
+  static class TurbineTypeParameterElement extends TurbineElement implements TypeParameterElement {
+
+    @Override
+    public int hashCode() {
+      return symbol.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj instanceof TurbineTypeParameterElement
+          && symbol.equals(((TurbineTypeParameterElement) obj).symbol);
+    }
+
+    private final TyVarSymbol symbol;
+
+    public TurbineTypeParameterElement(ModelFactory factory, TyVarSymbol symbol) {
+      super(factory);
+      this.symbol = symbol;
+    }
+
+    private final Supplier<TyVarInfo> info =
+        memoize(
+            new Supplier<TyVarInfo>() {
+              @Override
+              public TyVarInfo get() {
+                return factory.getTyVarInfo(symbol);
+              }
+            });
+
+    private TyVarInfo info() {
+      return info.get();
+    }
+
+    @Override
+    public String toString() {
+      return symbol.name();
+    }
+
+    @Override
+    public Element getGenericElement() {
+      return factory.element(symbol.owner());
+    }
+
+    @Override
+    public List<? extends TypeMirror> getBounds() {
+      return factory.asTypeMirrors(info().upperBound().bounds());
+    }
+
+    @Override
+    public TypeMirror asType() {
+      return factory.asTypeMirror(Type.TyVar.create(symbol, info().annotations()));
+    }
+
+    @Override
+    public ElementKind getKind() {
+      return ElementKind.TYPE_PARAMETER;
+    }
+
+    @Override
+    public Set<Modifier> getModifiers() {
+      return EnumSet.noneOf(Modifier.class);
+    }
+
+    @Override
+    public Name getSimpleName() {
+      return new TurbineName(symbol.name());
+    }
+
+    @Override
+    public Element getEnclosingElement() {
+      return getGenericElement();
+    }
+
+    @Override
+    public List<? extends Element> getEnclosedElements() {
+      return ImmutableList.of();
+    }
+
+    @Override
+    public <R, P> R accept(ElementVisitor<R, P> v, P p) {
+      return v.visitTypeParameter(this, p);
+    }
+  }
+
+  /** An {@link ExecutableElement} implementation backed by a {@link MethodSymbol}. */
+  static class TurbineExecutableElement extends TurbineElement implements ExecutableElement {
+
+    private final MethodSymbol sym;
+
+    private final Supplier<MethodInfo> info =
+        memoize(
+            new Supplier<MethodInfo>() {
+              @Override
+              public MethodInfo get() {
+                return factory.getMethodInfo(sym);
+              }
+            });
+
+    private MethodInfo info() {
+      return info.get();
+    }
+
+    TurbineExecutableElement(ModelFactory factory, MethodSymbol sym) {
+      super(factory);
+      this.sym = sym;
+    }
+
+    @Override
+    public int hashCode() {
+      return sym.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj instanceof TurbineExecutableElement
+          && sym.equals(((TurbineExecutableElement) obj).sym);
+    }
+
+    @Override
+    public List<? extends TypeParameterElement> getTypeParameters() {
+      ImmutableList.Builder<TurbineTypeParameterElement> result = ImmutableList.builder();
+      for (Map.Entry<TyVarSymbol, TyVarInfo> p : info().tyParams().entrySet()) {
+        result.add(factory.typeParameterElement(p.getKey()));
+      }
+      return result.build();
+    }
+
+    @Override
+    public TypeMirror getReturnType() {
+      return factory.asTypeMirror(info().returnType());
+    }
+
+    private final Supplier<ImmutableList<VariableElement>> parameters =
+        memoize(
+            new Supplier<ImmutableList<VariableElement>>() {
+              @Override
+              public ImmutableList<VariableElement> get() {
+                ImmutableList.Builder<VariableElement> result = ImmutableList.builder();
+                for (ParamInfo param : info().parameters()) {
+                  result.add(factory.parameterElement(param.sym()));
+                }
+                return result.build();
+              }
+            });
+
+    @Override
+    public List<? extends VariableElement> getParameters() {
+      return parameters.get();
+    }
+
+    @Override
+    public String toString() {
+      MethodInfo info = info();
+      StringBuilder sb = new StringBuilder();
+      if (!info.tyParams().isEmpty()) {
+        sb.append('<');
+        Joiner.on(',').appendTo(sb, info.tyParams().keySet());
+        sb.append('.');
+      }
+      if (getKind() == ElementKind.CONSTRUCTOR) {
+        sb.append(info.sym().owner().simpleName());
+      } else {
+        sb.append(info.sym().name());
+      }
+      sb.append('(');
+      boolean first = true;
+      for (ParamInfo p : info.parameters()) {
+        if (!first) {
+          sb.append(',');
+        }
+        sb.append(p.type());
+        first = false;
+      }
+      sb.append(')');
+      return sb.toString();
+    }
+
+    @Override
+    public TypeMirror getReceiverType() {
+      return info().receiver() != null
+          ? factory.asTypeMirror(info().receiver().type())
+          : factory.noType();
+    }
+
+    @Override
+    public boolean isVarArgs() {
+      return (info().access() & TurbineFlag.ACC_VARARGS) == TurbineFlag.ACC_VARARGS;
+    }
+
+    @Override
+    public boolean isDefault() {
+      return (info().access() & TurbineFlag.ACC_DEFAULT) == TurbineFlag.ACC_DEFAULT;
+    }
+
+    @Override
+    public List<? extends TypeMirror> getThrownTypes() {
+      return factory.asTypeMirrors(info().exceptions());
+    }
+
+    @Override
+    public AnnotationValue getDefaultValue() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TypeMirror asType() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ElementKind getKind() {
+      return info().name().equals("<init>") ? ElementKind.CONSTRUCTOR : ElementKind.METHOD;
+    }
+
+    @Override
+    public Set<Modifier> getModifiers() {
+      int access = info().access();
+      if (factory.getSymbol(info().sym().owner()).kind() == TurbineTyKind.INTERFACE) {
+        if ((access & (TurbineFlag.ACC_ABSTRACT | TurbineFlag.ACC_STATIC)) == 0) {
+          access |= TurbineFlag.ACC_DEFAULT;
+        }
+      }
+      return asModifierSet(ModifierOwner.METHOD, access);
+    }
+
+    @Override
+    public Name getSimpleName() {
+      return new TurbineName(info().sym().name());
+    }
+
+    @Override
+    public Element getEnclosingElement() {
+      return factory.typeElement(info().sym().owner());
+    }
+
+    @Override
+    public List<? extends Element> getEnclosedElements() {
+      return ImmutableList.of();
+    }
+
+    @Override
+    public <R, P> R accept(ElementVisitor<R, P> v, P p) {
+      return v.visitExecutable(this, p);
+    }
+  }
+
+  /** An {@link VariableElement} implementation backed by a {@link FieldSymbol}. */
+  static class TurbineFieldElement extends TurbineElement implements VariableElement {
+
+    @Override
+    public String toString() {
+      return sym.name();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj instanceof TurbineFieldElement && sym.equals(((TurbineFieldElement) obj).sym);
+    }
+
+    @Override
+    public int hashCode() {
+      return sym.hashCode();
+    }
+
+    private final FieldSymbol sym;
+
+    private final Supplier<FieldInfo> info =
+        memoize(
+            new Supplier<FieldInfo>() {
+              @Override
+              public FieldInfo get() {
+                return factory.getFieldInfo(sym);
+              }
+            });
+
+    FieldInfo info() {
+      return info.get();
+    }
+
+    TurbineFieldElement(ModelFactory factory, FieldSymbol symbol) {
+      super(factory);
+      this.sym = symbol;
+    }
+
+    @Override
+    public Object getConstantValue() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TypeMirror asType() {
+      return factory.asTypeMirror(info().type());
+    }
+
+    @Override
+    public ElementKind getKind() {
+      return ((info().access() & TurbineFlag.ACC_ENUM) == TurbineFlag.ACC_ENUM)
+          ? ElementKind.ENUM_CONSTANT
+          : ElementKind.FIELD;
+    }
+
+    @Override
+    public Set<Modifier> getModifiers() {
+      return asModifierSet(ModifierOwner.FIELD, info().access());
+    }
+
+    @Override
+    public Name getSimpleName() {
+      return new TurbineName(sym.name());
+    }
+
+    @Override
+    public Element getEnclosingElement() {
+      return factory.typeElement(sym.owner());
+    }
+
+    @Override
+    public List<? extends Element> getEnclosedElements() {
+      return ImmutableList.of();
+    }
+
+    @Override
+    public <R, P> R accept(ElementVisitor<R, P> v, P p) {
+      return v.visitVariable(this, p);
+    }
+  }
+
+  private enum ModifierOwner {
+    TYPE,
+    PARAMETER,
+    FIELD,
+    METHOD
+  }
+
+  private static EnumSet<Modifier> asModifierSet(ModifierOwner modifierOwner, int access) {
+    EnumSet<Modifier> modifiers = EnumSet.noneOf(Modifier.class);
+    if ((access & TurbineFlag.ACC_PUBLIC) == TurbineFlag.ACC_PUBLIC) {
+      modifiers.add(Modifier.PUBLIC);
+    }
+    if ((access & TurbineFlag.ACC_PROTECTED) == TurbineFlag.ACC_PROTECTED) {
+      modifiers.add(Modifier.PROTECTED);
+    }
+    if ((access & TurbineFlag.ACC_PRIVATE) == TurbineFlag.ACC_PRIVATE) {
+      modifiers.add(Modifier.PRIVATE);
+    }
+    if ((access & TurbineFlag.ACC_ABSTRACT) == TurbineFlag.ACC_ABSTRACT) {
+      modifiers.add(Modifier.ABSTRACT);
+    }
+    if ((access & TurbineFlag.ACC_FINAL) == TurbineFlag.ACC_FINAL) {
+      modifiers.add(Modifier.FINAL);
+    }
+    if ((access & TurbineFlag.ACC_DEFAULT) == TurbineFlag.ACC_DEFAULT) {
+      modifiers.add(Modifier.DEFAULT);
+    }
+    if ((access & TurbineFlag.ACC_STATIC) == TurbineFlag.ACC_STATIC) {
+      modifiers.add(Modifier.STATIC);
+    }
+    if ((access & TurbineFlag.ACC_TRANSIENT) == TurbineFlag.ACC_TRANSIENT) {
+      switch (modifierOwner) {
+        case METHOD:
+        case PARAMETER:
+          // varargs and transient use the same bits
+          break;
+        default:
+          modifiers.add(Modifier.TRANSIENT);
+      }
+    }
+    if ((access & TurbineFlag.ACC_VOLATILE) == TurbineFlag.ACC_VOLATILE) {
+      modifiers.add(Modifier.VOLATILE);
+    }
+    if ((access & TurbineFlag.ACC_SYNCHRONIZED) == TurbineFlag.ACC_SYNCHRONIZED) {
+      modifiers.add(Modifier.SYNCHRONIZED);
+    }
+    if ((access & TurbineFlag.ACC_NATIVE) == TurbineFlag.ACC_NATIVE) {
+      modifiers.add(Modifier.NATIVE);
+    }
+    if ((access & TurbineFlag.ACC_STRICT) == TurbineFlag.ACC_STRICT) {
+      modifiers.add(Modifier.STRICTFP);
+    }
+
+    return modifiers;
+  }
+
+  /** A {@link PackageElement} implementation backed by a {@link PackageSymbol}. */
+  static class TurbinePackageElement extends TurbineElement implements PackageElement {
+
+    private final PackageSymbol symbol;
+
+    public TurbinePackageElement(ModelFactory factory, PackageSymbol symbol) {
+      super(factory);
+      this.symbol = symbol;
+    }
+
+    @Override
+    public Name getQualifiedName() {
+      return new TurbineName(symbol.toString());
+    }
+
+    @Override
+    public boolean isUnnamed() {
+      return symbol.binaryName().isEmpty();
+    }
+
+    @Override
+    public TypeMirror asType() {
+      return factory.packageType(symbol);
+    }
+
+    @Override
+    public ElementKind getKind() {
+      return ElementKind.PACKAGE;
+    }
+
+    @Override
+    public Set<Modifier> getModifiers() {
+      return EnumSet.noneOf(Modifier.class);
+    }
+
+    @Override
+    public Name getSimpleName() {
+      return new TurbineName(
+          symbol.binaryName().substring(symbol.binaryName().lastIndexOf('/') + 1));
+    }
+
+    @Override
+    public Element getEnclosingElement() {
+      // a package is not enclosed by another element
+      return null;
+    }
+
+    @Override
+    public List<TurbineTypeElement> getEnclosedElements() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <R, P> R accept(ElementVisitor<R, P> v, P p) {
+      return v.visitPackage(this, p);
+    }
+
+    @Override
+    public int hashCode() {
+      return symbol.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj instanceof TurbinePackageElement
+          && symbol.equals(((TurbinePackageElement) obj).symbol);
+    }
+
+    @Override
+    public String toString() {
+      return symbol.toString();
+    }
+  }
+
+  /** A {@liVariableElement PackageElement} implementation backed by a {@link ParamSymbol}. */
+  static class TurbineParameterElement extends TurbineElement implements VariableElement {
+
+    @Override
+    public int hashCode() {
+      return sym.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj instanceof TurbineParameterElement
+          && sym.equals(((TurbineParameterElement) obj).sym);
+    }
+
+    private final ParamSymbol sym;
+
+    private final Supplier<ParamInfo> info =
+        memoize(
+            new Supplier<ParamInfo>() {
+              @Override
+              public ParamInfo get() {
+                return factory.getParamInfo(sym);
+              }
+            });
+
+    ParamInfo info() {
+      return info.get();
+    }
+
+    public TurbineParameterElement(ModelFactory factory, ParamSymbol sym) {
+      super(factory);
+      this.sym = sym;
+    }
+
+    @Override
+    public Object getConstantValue() {
+      return null;
+    }
+
+    private final Supplier<TypeMirror> type =
+        memoize(
+            new Supplier<TypeMirror>() {
+              @Override
+              public TypeMirror get() {
+                return factory.asTypeMirror(info().type());
+              }
+            });
+
+    @Override
+    public TypeMirror asType() {
+      return type.get();
+    }
+
+    @Override
+    public ElementKind getKind() {
+      return ElementKind.PARAMETER;
+    }
+
+    @Override
+    public Set<Modifier> getModifiers() {
+      return asModifierSet(ModifierOwner.PARAMETER, info().access());
+    }
+
+    @Override
+    public Name getSimpleName() {
+      return new TurbineName(sym.name());
+    }
+
+    @Override
+    public Element getEnclosingElement() {
+      return factory.executableElement(sym.owner());
+    }
+
+    @Override
+    public List<? extends Element> getEnclosedElements() {
+      return ImmutableList.of();
+    }
+
+    @Override
+    public <R, P> R accept(ElementVisitor<R, P> v, P p) {
+      return v.visitVariable(this, p);
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(sym.name());
+    }
+  }
+}

--- a/java/com/google/turbine/processing/TurbineElement.java
+++ b/java/com/google/turbine/processing/TurbineElement.java
@@ -63,6 +63,8 @@ import javax.lang.model.type.TypeMirror;
 /** An {@link Element} implementation backed by a {@link Symbol}. */
 public abstract class TurbineElement implements Element {
 
+  public abstract Symbol sym();
+
   @Override
   public abstract int hashCode();
 
@@ -99,23 +101,23 @@ public abstract class TurbineElement implements Element {
 
     @Override
     public int hashCode() {
-      return symbol.hashCode();
+      return sym.hashCode();
     }
 
-    private final ClassSymbol symbol;
+    private final ClassSymbol sym;
     private final Supplier<TypeBoundClass> info;
 
-    TurbineTypeElement(ModelFactory factory, ClassSymbol symbol) {
+    TurbineTypeElement(ModelFactory factory, ClassSymbol sym) {
       super(factory);
       requireNonNull(factory);
-      requireNonNull(symbol);
-      this.symbol = symbol;
+      requireNonNull(sym);
+      this.sym = sym;
       this.info =
           memoize(
               new Supplier<TypeBoundClass>() {
                 @Override
                 public TypeBoundClass get() {
-                  return factory.getSymbol(symbol);
+                  return factory.getSymbol(sym);
                 }
               });
     }
@@ -137,7 +139,7 @@ public abstract class TurbineElement implements Element {
               public TurbineName get() {
                 TypeBoundClass info = info();
                 if (info == null || info.owner() == null) {
-                  return new TurbineName(symbol.toString());
+                  return new TurbineName(sym.toString());
                 }
                 ClassSymbol sym = sym();
                 Deque<String> flat = new ArrayDeque<>();
@@ -224,7 +226,7 @@ public abstract class TurbineElement implements Element {
             new Supplier<TypeMirror>() {
               @Override
               public TypeMirror get() {
-                return factory.asTypeMirror(asGenericType(symbol));
+                return factory.asTypeMirror(asGenericType(sym));
               }
 
               ClassTy asGenericType(ClassSymbol symbol) {
@@ -284,10 +286,10 @@ public abstract class TurbineElement implements Element {
               public TurbineName get() {
                 TypeBoundClass info = info();
                 if (info == null || info.owner() == null) {
-                  return new TurbineName(symbol.simpleName());
+                  return new TurbineName(sym.simpleName());
                 }
                 return new TurbineName(
-                    symbol.binaryName().substring(info.owner().binaryName().length() + 1));
+                    sym.binaryName().substring(info.owner().binaryName().length() + 1));
               }
             });
 
@@ -305,7 +307,7 @@ public abstract class TurbineElement implements Element {
                 if (info != null && info.owner() != null) {
                   return factory.typeElement(info.owner());
                 }
-                return factory.packageElement(symbol.owner());
+                return factory.packageElement(sym.owner());
               }
             });
 
@@ -344,13 +346,14 @@ public abstract class TurbineElement implements Element {
       return v.visitType(this, p);
     }
 
+    @Override
     public ClassSymbol sym() {
-      return symbol;
+      return sym;
     }
 
     @Override
     public boolean equals(Object obj) {
-      return obj instanceof TurbineTypeElement && symbol.equals(((TurbineTypeElement) obj).symbol);
+      return obj instanceof TurbineTypeElement && sym.equals(((TurbineTypeElement) obj).sym);
     }
   }
 
@@ -359,20 +362,20 @@ public abstract class TurbineElement implements Element {
 
     @Override
     public int hashCode() {
-      return symbol.hashCode();
+      return sym.hashCode();
     }
 
     @Override
     public boolean equals(Object obj) {
       return obj instanceof TurbineTypeParameterElement
-          && symbol.equals(((TurbineTypeParameterElement) obj).symbol);
+          && sym.equals(((TurbineTypeParameterElement) obj).sym);
     }
 
-    private final TyVarSymbol symbol;
+    private final TyVarSymbol sym;
 
-    public TurbineTypeParameterElement(ModelFactory factory, TyVarSymbol symbol) {
+    public TurbineTypeParameterElement(ModelFactory factory, TyVarSymbol sym) {
       super(factory);
-      this.symbol = symbol;
+      this.sym = sym;
     }
 
     private final Supplier<TyVarInfo> info =
@@ -380,7 +383,7 @@ public abstract class TurbineElement implements Element {
             new Supplier<TyVarInfo>() {
               @Override
               public TyVarInfo get() {
-                return factory.getTyVarInfo(symbol);
+                return factory.getTyVarInfo(sym);
               }
             });
 
@@ -390,12 +393,12 @@ public abstract class TurbineElement implements Element {
 
     @Override
     public String toString() {
-      return symbol.name();
+      return sym.name();
     }
 
     @Override
     public Element getGenericElement() {
-      return factory.element(symbol.owner());
+      return factory.element(sym.owner());
     }
 
     @Override
@@ -405,7 +408,7 @@ public abstract class TurbineElement implements Element {
 
     @Override
     public TypeMirror asType() {
-      return factory.asTypeMirror(Type.TyVar.create(symbol, info().annotations()));
+      return factory.asTypeMirror(Type.TyVar.create(sym, info().annotations()));
     }
 
     @Override
@@ -420,7 +423,7 @@ public abstract class TurbineElement implements Element {
 
     @Override
     public Name getSimpleName() {
-      return new TurbineName(symbol.name());
+      return new TurbineName(sym.name());
     }
 
     @Override
@@ -438,8 +441,9 @@ public abstract class TurbineElement implements Element {
       return v.visitTypeParameter(this, p);
     }
 
+    @Override
     public TyVarSymbol sym() {
-      return symbol;
+      return sym;
     }
   }
 
@@ -464,6 +468,11 @@ public abstract class TurbineElement implements Element {
     TurbineExecutableElement(ModelFactory factory, MethodSymbol sym) {
       super(factory);
       this.sym = sym;
+    }
+
+    @Override
+    public MethodSymbol sym() {
+      return sym;
     }
 
     @Override
@@ -624,6 +633,11 @@ public abstract class TurbineElement implements Element {
 
     private final FieldSymbol sym;
 
+    @Override
+    public FieldSymbol sym() {
+      return sym;
+    }
+
     private final Supplier<FieldInfo> info =
         memoize(
             new Supplier<FieldInfo>() {
@@ -637,9 +651,9 @@ public abstract class TurbineElement implements Element {
       return info.get();
     }
 
-    TurbineFieldElement(ModelFactory factory, FieldSymbol symbol) {
+    TurbineFieldElement(ModelFactory factory, FieldSymbol sym) {
       super(factory);
-      this.sym = symbol;
+      this.sym = sym;
     }
 
     @Override
@@ -744,26 +758,26 @@ public abstract class TurbineElement implements Element {
   /** A {@link PackageElement} implementation backed by a {@link PackageSymbol}. */
   static class TurbinePackageElement extends TurbineElement implements PackageElement {
 
-    private final PackageSymbol symbol;
+    private final PackageSymbol sym;
 
-    public TurbinePackageElement(ModelFactory factory, PackageSymbol symbol) {
+    public TurbinePackageElement(ModelFactory factory, PackageSymbol sym) {
       super(factory);
-      this.symbol = symbol;
+      this.sym = sym;
     }
 
     @Override
     public Name getQualifiedName() {
-      return new TurbineName(symbol.toString());
+      return new TurbineName(sym.toString());
     }
 
     @Override
     public boolean isUnnamed() {
-      return symbol.binaryName().isEmpty();
+      return sym.binaryName().isEmpty();
     }
 
     @Override
     public TypeMirror asType() {
-      return factory.packageType(symbol);
+      return factory.packageType(sym);
     }
 
     @Override
@@ -778,8 +792,7 @@ public abstract class TurbineElement implements Element {
 
     @Override
     public Name getSimpleName() {
-      return new TurbineName(
-          symbol.binaryName().substring(symbol.binaryName().lastIndexOf('/') + 1));
+      return new TurbineName(sym.binaryName().substring(sym.binaryName().lastIndexOf('/') + 1));
     }
 
     @Override
@@ -799,24 +812,33 @@ public abstract class TurbineElement implements Element {
     }
 
     @Override
+    public PackageSymbol sym() {
+      return sym;
+    }
+
+    @Override
     public int hashCode() {
-      return symbol.hashCode();
+      return sym.hashCode();
     }
 
     @Override
     public boolean equals(Object obj) {
-      return obj instanceof TurbinePackageElement
-          && symbol.equals(((TurbinePackageElement) obj).symbol);
+      return obj instanceof TurbinePackageElement && sym.equals(((TurbinePackageElement) obj).sym);
     }
 
     @Override
     public String toString() {
-      return symbol.toString();
+      return sym.toString();
     }
   }
 
   /** A {@liVariableElement PackageElement} implementation backed by a {@link ParamSymbol}. */
   static class TurbineParameterElement extends TurbineElement implements VariableElement {
+
+    @Override
+    public ParamSymbol sym() {
+      return sym;
+    }
 
     @Override
     public int hashCode() {

--- a/java/com/google/turbine/processing/TurbineElement.java
+++ b/java/com/google/turbine/processing/TurbineElement.java
@@ -437,6 +437,10 @@ public abstract class TurbineElement implements Element {
     public <R, P> R accept(ElementVisitor<R, P> v, P p) {
       return v.visitTypeParameter(this, p);
     }
+
+    public TyVarSymbol sym() {
+      return symbol;
+    }
   }
 
   /** An {@link ExecutableElement} implementation backed by a {@link MethodSymbol}. */
@@ -453,7 +457,7 @@ public abstract class TurbineElement implements Element {
               }
             });
 
-    private MethodInfo info() {
+    MethodInfo info() {
       return info.get();
     }
 
@@ -512,7 +516,7 @@ public abstract class TurbineElement implements Element {
       if (!info.tyParams().isEmpty()) {
         sb.append('<');
         Joiner.on(',').appendTo(sb, info.tyParams().keySet());
-        sb.append('.');
+        sb.append('>');
       }
       if (getKind() == ElementKind.CONSTRUCTOR) {
         sb.append(info.sym().owner().simpleName());
@@ -534,9 +538,8 @@ public abstract class TurbineElement implements Element {
 
     @Override
     public TypeMirror getReceiverType() {
-      return info().receiver() != null
-          ? factory.asTypeMirror(info().receiver().type())
-          : factory.noType();
+      // TODO(cushon): javac returns null, the spec says NONE
+      return info().receiver() != null ? factory.asTypeMirror(info().receiver().type()) : null;
     }
 
     @Override

--- a/java/com/google/turbine/processing/TurbineElement.java
+++ b/java/com/google/turbine/processing/TurbineElement.java
@@ -832,7 +832,7 @@ public abstract class TurbineElement implements Element {
     }
   }
 
-  /** A {@liVariableElement PackageElement} implementation backed by a {@link ParamSymbol}. */
+  /** A {@link VariableElement} implementation backed by a {@link ParamSymbol}. */
   static class TurbineParameterElement extends TurbineElement implements VariableElement {
 
     @Override

--- a/java/com/google/turbine/processing/TurbineElement.java
+++ b/java/com/google/turbine/processing/TurbineElement.java
@@ -109,9 +109,7 @@ public abstract class TurbineElement implements Element {
 
     TurbineTypeElement(ModelFactory factory, ClassSymbol sym) {
       super(factory);
-      requireNonNull(factory);
-      requireNonNull(sym);
-      this.sym = sym;
+      this.sym = requireNonNull(sym);
       this.info =
           memoize(
               new Supplier<TypeBoundClass>() {

--- a/java/com/google/turbine/processing/TurbineElement.java
+++ b/java/com/google/turbine/processing/TurbineElement.java
@@ -564,7 +564,7 @@ public abstract class TurbineElement implements Element {
 
     @Override
     public TypeMirror asType() {
-      throw new UnsupportedOperationException();
+      return factory.asTypeMirror(info().asType());
     }
 
     @Override

--- a/java/com/google/turbine/processing/TurbineElements.java
+++ b/java/com/google/turbine/processing/TurbineElements.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
+import com.google.turbine.binder.sym.ClassSymbol;
+import com.google.turbine.binder.sym.FieldSymbol;
+import com.google.turbine.binder.sym.MethodSymbol;
+import com.google.turbine.binder.sym.PackageSymbol;
+import com.google.turbine.binder.sym.ParamSymbol;
+import com.google.turbine.binder.sym.Symbol;
+import com.google.turbine.binder.sym.TyVarSymbol;
+import com.google.turbine.model.TurbineVisibility;
+import com.google.turbine.processing.TurbineElement.TurbineExecutableElement;
+import com.google.turbine.processing.TurbineElement.TurbineFieldElement;
+import com.google.turbine.processing.TurbineTypeMirror.TurbineExecutableType;
+import java.io.Writer;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+
+/** An implementation of {@link Elements} backed by turbine's {@link Element}. */
+public class TurbineElements implements Elements {
+
+  private final ModelFactory factory;
+  private final TurbineTypes types;
+
+  public TurbineElements(ModelFactory factory, TurbineTypes types) {
+    this.factory = factory;
+    this.types = types;
+  }
+
+  private static Symbol asSymbol(Element element) {
+    if (!(element instanceof TurbineElement)) {
+      throw new IllegalArgumentException(element.toString());
+    }
+    return ((TurbineElement) element).sym();
+  }
+
+  @Override
+  public PackageElement getPackageElement(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public TypeElement getTypeElement(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Map<? extends ExecutableElement, ? extends AnnotationValue> getElementValuesWithDefaults(
+      AnnotationMirror a) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getDocComment(Element e) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isDeprecated(Element e) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Name getBinaryName(TypeElement type) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @throws IllegalArgumentException for module elements
+   */
+  @Override
+  public PackageElement getPackageOf(Element element) {
+    Symbol sym = asSymbol(element);
+    return factory.packageElement(packageSymbol(sym));
+  }
+
+  private static PackageSymbol packageSymbol(Symbol sym) {
+    switch (sym.symKind()) {
+      case CLASS:
+        return ((ClassSymbol) sym).owner();
+      case TY_PARAM:
+        return packageSymbol(((TyVarSymbol) sym).owner());
+      case METHOD:
+        return ((MethodSymbol) sym).owner().owner();
+      case FIELD:
+        return ((FieldSymbol) sym).owner().owner();
+      case PARAMETER:
+        return ((ParamSymbol) sym).owner().owner().owner();
+      case PACKAGE:
+        return (PackageSymbol) sym;
+      case MODULE:
+        throw new IllegalArgumentException(sym.toString());
+    }
+    throw new AssertionError(sym.symKind());
+  }
+
+  @Override
+  public List<? extends Element> getAllMembers(TypeElement type) {
+    ClassSymbol s = (ClassSymbol) asSymbol(type);
+    PackageSymbol from = packageSymbol(s);
+
+    // keep track of processed methods grouped by their names, to handle overrides more efficiently
+    Multimap<String, TurbineExecutableElement> methods =
+        MultimapBuilder.linkedHashKeys().linkedHashSetValues().build();
+
+    // collect all members of each transitive supertype of the input
+    ImmutableList.Builder<Element> results = ImmutableList.builder();
+    for (ClassSymbol superType : factory.cha().transitiveSupertypes(s)) {
+      // Most of JSR-269 is implemented on top of turbine's model, instead of the Element and
+      // TypeMirror wrappers. We don't do that here because we need most of the Elements returned
+      // by getEnclosedElements anyways, and the work below benefits from some of the caching done
+      // by TurbineElement.
+      for (Element el : factory.typeElement(superType).getEnclosedElements()) {
+        Symbol sym = asSymbol(el);
+        switch (sym.symKind()) {
+          case METHOD:
+            TurbineExecutableElement m = (TurbineExecutableElement) el;
+            if (shouldAdd(s, from, methods, m)) {
+              methods.put(m.info().name(), m);
+              results.add(el);
+            }
+            break;
+          case FIELD:
+            if (shouldAdd(s, from, (TurbineFieldElement) el)) {
+              results.add(el);
+            }
+            break;
+          default:
+            results.add(el);
+        }
+      }
+    }
+    return results.build();
+  }
+
+  private boolean shouldAdd(
+      ClassSymbol s,
+      PackageSymbol from,
+      Multimap<String, TurbineExecutableElement> methods,
+      TurbineExecutableElement m) {
+    if (m.sym().owner().equals(s)) {
+      // always include methods (and constructors) declared in the given type
+      return true;
+    }
+    if (m.getKind() == ElementKind.CONSTRUCTOR) {
+      // skip constructors from super-types, because the spec says so
+      return false;
+    }
+    if (!isVisible(from, packageSymbol(m.sym()), TurbineVisibility.fromAccess(m.info().access()))) {
+      // skip invisible methods in supers
+      return false;
+    }
+    // otherwise check if we've seen methods that override, or are overridden by, the
+    // current method
+    Set<TurbineExecutableElement> overrides = new HashSet<>();
+    Set<TurbineExecutableElement> overridden = new HashSet<>();
+    String name = m.info().name();
+    for (TurbineExecutableElement other : methods.get(name)) {
+      if (overrides(m, other, (TypeElement) m.getEnclosingElement())) {
+        overrides.add(other);
+        continue;
+      }
+      if (overrides(other, m, (TypeElement) other.getEnclosingElement())) {
+        overridden.add(other);
+        continue;
+      }
+    }
+    if (!overridden.isEmpty()) {
+      // We've already processed method(s) that override this one; nothing to do here.
+      // If that's true, and we've *also* processed a methods that this one overrides,
+      // something has gone terribly wrong: since overriding is transitive the results
+      // contain a pair of methods that override each other.
+      checkState(overrides.isEmpty());
+      return false;
+    }
+    // Add this method, and remove any methods we've already processed that it overrides.
+    for (TurbineExecutableElement override : overrides) {
+      methods.remove(name, override);
+    }
+    return true;
+  }
+
+  private static boolean shouldAdd(ClassSymbol s, PackageSymbol from, TurbineFieldElement f) {
+    FieldSymbol sym = f.sym();
+    if (sym.owner().equals(s)) {
+      // always include fields declared in the given type
+      return true;
+    }
+    if (!isVisible(from, packageSymbol(sym), TurbineVisibility.fromAccess(f.info().access()))) {
+      // skip invisible fields in supers
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Returns true if an element with the given {@code visibility} and located in package {@from} is
+   * visible to elements in package {@code to}.
+   */
+  private static boolean isVisible(
+      PackageSymbol from, PackageSymbol to, TurbineVisibility visibility) {
+    switch (visibility) {
+      case PUBLIC:
+      case PROTECTED:
+        break;
+      case PACKAGE:
+        return from.equals(to);
+      case PRIVATE:
+        return false;
+    }
+    return true;
+  }
+
+  @Override
+  public List<? extends AnnotationMirror> getAllAnnotationMirrors(Element e) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean hides(Element hider, Element hidden) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean overrides(
+      ExecutableElement overrider, ExecutableElement overridden, TypeElement type) {
+    TypeMirror a = overrider.asType();
+    TypeMirror b = types.asMemberOf((DeclaredType) type.asType(), overridden);
+    if (b == null) {
+      return false;
+    }
+    if (!types.isSubsignature((TurbineExecutableType) a, (TurbineExecutableType) b)) {
+      return false;
+    }
+    return isVisible(
+        packageSymbol(asSymbol(overrider)),
+        packageSymbol(asSymbol(overridden)),
+        TurbineVisibility.fromAccess(((TurbineExecutableElement) overridden).info().access()));
+  }
+
+  @Override
+  public String getConstantExpression(Object value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void printElements(Writer w, Element... elements) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Name getName(CharSequence cs) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isFunctionalInterface(TypeElement type) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/java/com/google/turbine/processing/TurbineName.java
+++ b/java/com/google/turbine/processing/TurbineName.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static java.util.Objects.requireNonNull;
+
+import javax.lang.model.element.Name;
+
+/** An implementation of {@link Name} backed by a {@link CharSequence}. */
+public class TurbineName implements Name {
+
+  private final CharSequence name;
+
+  public TurbineName(CharSequence name) {
+    requireNonNull(name);
+    this.name = name;
+  }
+
+  @Override
+  public boolean contentEquals(CharSequence cs) {
+    return name.toString().contentEquals(cs);
+  }
+
+  @Override
+  public int length() {
+    return name.length();
+  }
+
+  @Override
+  public char charAt(int index) {
+    return name.charAt(index);
+  }
+
+  @Override
+  public CharSequence subSequence(int start, int end) {
+    return name.subSequence(start, end);
+  }
+
+  @Override
+  public String toString() {
+    return name.toString();
+  }
+
+  @Override
+  public int hashCode() {
+    return name.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof TurbineName && contentEquals(((TurbineName) obj).name);
+  }
+}

--- a/java/com/google/turbine/processing/TurbineTypeMirror.java
+++ b/java/com/google/turbine/processing/TurbineTypeMirror.java
@@ -155,7 +155,7 @@ public abstract class TurbineTypeMirror implements TypeMirror {
     }
 
     @Override
-    public Type asTurbineType() {
+    public ClassTy asTurbineType() {
       return type;
     }
 

--- a/java/com/google/turbine/processing/TurbineTypeMirror.java
+++ b/java/com/google/turbine/processing/TurbineTypeMirror.java
@@ -1,0 +1,533 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.collect.Iterables.getLast;
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.base.Ascii;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
+import com.google.turbine.binder.bound.TypeBoundClass;
+import com.google.turbine.binder.bound.TypeBoundClass.TyVarInfo;
+import com.google.turbine.binder.sym.PackageSymbol;
+import com.google.turbine.model.TurbineConstantTypeKind;
+import com.google.turbine.type.Type;
+import com.google.turbine.type.Type.ArrayTy;
+import com.google.turbine.type.Type.ClassTy;
+import com.google.turbine.type.Type.IntersectionTy;
+import com.google.turbine.type.Type.PrimTy;
+import com.google.turbine.type.Type.TyVar;
+import com.google.turbine.type.Type.WildTy;
+import com.google.turbine.type.Type.WildTy.BoundKind;
+import java.lang.annotation.Annotation;
+import java.util.List;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.IntersectionType;
+import javax.lang.model.type.NoType;
+import javax.lang.model.type.PrimitiveType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
+import javax.lang.model.type.TypeVisitor;
+import javax.lang.model.type.WildcardType;
+
+/** A {@link TypeMirror} implementation backed by a {@link Type}. */
+public abstract class TurbineTypeMirror implements TypeMirror {
+
+  protected final ModelFactory factory;
+
+  protected TurbineTypeMirror(ModelFactory factory) {
+    this.factory = requireNonNull(factory);
+  }
+
+  @Override
+  public final List<? extends AnnotationMirror> getAnnotationMirrors() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public final <A extends Annotation> A getAnnotation(Class<A> annotationType) {
+    throw new AssertionError();
+  }
+
+  @Override
+  public final <A extends Annotation> A[] getAnnotationsByType(Class<A> annotationType) {
+    throw new AssertionError();
+  }
+
+  public abstract Type asTurbineType();
+
+  @Override
+  public String toString() {
+    return asTurbineType().toString();
+  }
+
+  /** A {@link PrimitiveType} implementation backed by a {@link PrimTy}. */
+  static class TurbinePrimitiveType extends TurbineTypeMirror implements PrimitiveType {
+
+    @Override
+    public String toString() {
+      return Ascii.toLowerCase(type.primkind().toString());
+    }
+
+    @Override
+    public Type asTurbineType() {
+      return type;
+    }
+
+    public final PrimTy type;
+
+    TurbinePrimitiveType(ModelFactory factory, PrimTy type) {
+      super(factory);
+      if (type.primkind() == TurbineConstantTypeKind.STRING) {
+        throw new AssertionError(type);
+      }
+      this.type = type;
+    }
+
+    @Override
+    public TypeKind getKind() {
+      switch (type.primkind()) {
+        case CHAR:
+          return TypeKind.CHAR;
+        case SHORT:
+          return TypeKind.SHORT;
+        case INT:
+          return TypeKind.INT;
+        case LONG:
+          return TypeKind.LONG;
+        case FLOAT:
+          return TypeKind.FLOAT;
+        case DOUBLE:
+          return TypeKind.DOUBLE;
+        case BOOLEAN:
+          return TypeKind.BOOLEAN;
+        case BYTE:
+          return TypeKind.BYTE;
+        case NULL:
+          return TypeKind.NULL;
+        case STRING:
+      }
+      throw new AssertionError(type.primkind());
+    }
+
+    @Override
+    public <R, P> R accept(TypeVisitor<R, P> v, P p) {
+      return v.visitPrimitive(this, p);
+    }
+  }
+
+  /** A {@link DeclaredType} implementation backed by a {@link ClassTy}. */
+  static class TurbineDeclaredType extends TurbineTypeMirror implements DeclaredType {
+
+    @Override
+    public int hashCode() {
+      return type.sym().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj instanceof TurbineDeclaredType && type.equals(((TurbineDeclaredType) obj).type);
+    }
+
+    @Override
+    public Type asTurbineType() {
+      return type;
+    }
+
+    private final ClassTy type;
+
+    TurbineDeclaredType(ModelFactory factory, ClassTy type) {
+      super(factory);
+      this.type = type;
+    }
+
+    @Override
+    public String toString() {
+      return type.toString();
+    }
+
+    final Supplier<Element> element =
+        factory.memoize(
+            new Supplier<Element>() {
+              @Override
+              public Element get() {
+                return factory.typeElement(type.sym());
+              }
+            });
+
+    @Override
+    public Element asElement() {
+      return element.get();
+    }
+
+    final Supplier<TypeMirror> enclosing =
+        factory.memoize(
+            new Supplier<TypeMirror>() {
+              @Override
+              public TypeMirror get() {
+                if (type.classes().size() > 1) {
+                  return factory.asTypeMirror(
+                      ClassTy.create(type.classes().subList(0, type.classes().size() - 1)));
+                }
+                // Instead of validating that all ClassTy implementations have entries corresponding
+                // to enclosing types, we allow non-canonical instances and then explicit check
+                // for enclosing instances.
+                TypeBoundClass info = factory.getSymbol(type.sym());
+                if (info != null && info.owner() != null) {
+                  return factory.asTypeMirror(ClassTy.asNonParametricClassTy(info.owner()));
+                }
+                return factory.noType();
+              }
+            });
+
+    @Override
+    public TypeMirror getEnclosingType() {
+      return enclosing.get();
+    }
+
+    final Supplier<ImmutableList<TypeMirror>> typeArguments =
+        factory.memoize(
+            new Supplier<ImmutableList<TypeMirror>>() {
+              @Override
+              public ImmutableList<TypeMirror> get() {
+                return factory.asTypeMirrors(getLast(type.classes()).targs());
+              }
+            });
+
+    @Override
+    public List<? extends TypeMirror> getTypeArguments() {
+      return typeArguments.get();
+    }
+
+    @Override
+    public TypeKind getKind() {
+      return TypeKind.DECLARED;
+    }
+
+    @Override
+    public <R, P> R accept(TypeVisitor<R, P> v, P p) {
+      return v.visitDeclared(this, p);
+    }
+  }
+
+  /** An {@link ArrayType} implementation backed by a {@link ArrayTy}. */
+  static class TurbineArrayType extends TurbineTypeMirror implements ArrayType {
+
+    @Override
+    public Type asTurbineType() {
+      return type;
+    }
+
+    private final ArrayTy type;
+
+    TurbineArrayType(ModelFactory factory, ArrayTy type) {
+      super(factory);
+      this.type = type;
+    }
+
+    @Override
+    public TypeMirror getComponentType() {
+      return factory.asTypeMirror(type.elementType());
+    }
+
+    @Override
+    public TypeKind getKind() {
+      return TypeKind.ARRAY;
+    }
+
+    @Override
+    public <R, P> R accept(TypeVisitor<R, P> v, P p) {
+      return v.visitArray(this, p);
+    }
+  }
+
+  /** A 'package type' implementation backed by a {@link PackageSymbol}. */
+  static class TurbinePackageType extends TurbineTypeMirror implements NoType {
+
+    @Override
+    public Type asTurbineType() {
+      throw new UnsupportedOperationException();
+    }
+
+    final PackageSymbol symbol;
+
+    TurbinePackageType(ModelFactory factory, PackageSymbol symbol) {
+      super(factory);
+      this.symbol = symbol;
+    }
+
+    @Override
+    public TypeKind getKind() {
+      return TypeKind.PACKAGE;
+    }
+
+    @Override
+    public <R, P> R accept(TypeVisitor<R, P> v, P p) {
+      return v.visitNoType(this, p);
+    }
+
+    @Override
+    public String toString() {
+      return symbol.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      return other instanceof TurbinePackageType
+          && symbol.equals(((TurbinePackageType) other).symbol);
+    }
+
+    @Override
+    public int hashCode() {
+      return getKind().hashCode();
+    }
+  }
+
+  /** The absence of a type, {@see javax.lang.model.util.Types#getNoType}. */
+  static class TurbineNoType extends TurbineTypeMirror implements NoType {
+
+    @Override
+    public Type asTurbineType() {
+      throw new UnsupportedOperationException();
+    }
+
+    TurbineNoType(ModelFactory factory) {
+      super(factory);
+    }
+
+    @Override
+    public TypeKind getKind() {
+      return TypeKind.NONE;
+    }
+
+    @Override
+    public <R, P> R accept(TypeVisitor<R, P> v, P p) {
+      return v.visitNoType(this, p);
+    }
+
+    @Override
+    public String toString() {
+      return "<notype>";
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      return other instanceof TurbineNoType;
+    }
+
+    @Override
+    public int hashCode() {
+      return getKind().hashCode();
+    }
+  }
+
+  /** A void type, {@see javax.lang.model.util.Types#getNoType}. */
+  static class TurbineVoidType extends TurbineTypeMirror implements NoType {
+
+    @Override
+    public Type asTurbineType() {
+      return Type.VOID;
+    }
+
+    TurbineVoidType(ModelFactory factory) {
+      super(factory);
+    }
+
+    @Override
+    public TypeKind getKind() {
+      return TypeKind.VOID;
+    }
+
+    @Override
+    public <R, P> R accept(TypeVisitor<R, P> v, P p) {
+      return v.visitNoType(this, p);
+    }
+  }
+
+  /** A {@link TypeVariable} implementation backed by a {@link TyVar}. */
+  static class TurbineTypeVariable extends TurbineTypeMirror implements TypeVariable {
+
+    @Override
+    public int hashCode() {
+      return type.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj instanceof TurbineTypeVariable && type.equals(((TurbineTypeVariable) obj).type);
+    }
+
+    @Override
+    public Type asTurbineType() {
+      return type;
+    }
+
+    private final TyVar type;
+
+    private final Supplier<TyVarInfo> info =
+        factory.memoize(
+            new Supplier<TyVarInfo>() {
+              @Override
+              public TyVarInfo get() {
+                return factory.getTyVarInfo(type.sym());
+              }
+            });
+
+    private TyVarInfo info() {
+      return info.get();
+    }
+
+    TurbineTypeVariable(ModelFactory factory, Type.TyVar type) {
+      super(factory);
+      this.type = type;
+    }
+
+    @Override
+    public TypeKind getKind() {
+      return TypeKind.TYPEVAR;
+    }
+
+    @Override
+    public <R, P> R accept(TypeVisitor<R, P> v, P p) {
+      return v.visitTypeVariable(this, p);
+    }
+
+    @Override
+    public Element asElement() {
+      return factory.typeParameterElement(type.sym());
+    }
+
+    @Override
+    public TypeMirror getUpperBound() {
+      return factory.asTypeMirror(info().upperBound());
+    }
+
+    @Override
+    public TypeMirror getLowerBound() {
+      return info().lowerBound() != null
+          ? factory.asTypeMirror(info().lowerBound())
+          : factory.noType();
+    }
+
+    @Override
+    public String toString() {
+      return type.toString();
+    }
+  }
+
+  /** A {@link WildcardType} implementation backed by a {@link WildTy}. */
+  static class TurbineWildcardType extends TurbineTypeMirror implements WildcardType {
+
+    @Override
+    public Type asTurbineType() {
+      return type;
+    }
+
+    private final WildTy type;
+
+    public TurbineWildcardType(ModelFactory factory, WildTy type) {
+      super(factory);
+      this.type = type;
+    }
+
+    @Override
+    public TypeKind getKind() {
+      return TypeKind.WILDCARD;
+    }
+
+    @Override
+    public <R, P> R accept(TypeVisitor<R, P> v, P p) {
+      return v.visitWildcard(this, p);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj instanceof TurbineWildcardType && type.equals(((TurbineWildcardType) obj).type);
+    }
+
+    @Override
+    public int hashCode() {
+      return type.hashCode();
+    }
+
+    @Override
+    public TypeMirror getExtendsBound() {
+      return type.boundKind() == BoundKind.UPPER ? factory.asTypeMirror(type.bound()) : null;
+    }
+
+    @Override
+    public TypeMirror getSuperBound() {
+      return type.boundKind() == BoundKind.LOWER ? factory.asTypeMirror(type.bound()) : null;
+    }
+  }
+
+  /** A {@link IntersectionType} implementation backed by a {@link IntersectionTy}. */
+  static class TurbineIntersectionType extends TurbineTypeMirror implements IntersectionType {
+
+    @Override
+    public Type asTurbineType() {
+      return type;
+    }
+
+    private final IntersectionTy type;
+
+    TurbineIntersectionType(ModelFactory factory, IntersectionTy type) {
+      super(factory);
+      this.type = type;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj instanceof TurbineIntersectionType
+          && type.equals(((TurbineIntersectionType) obj).type);
+    }
+
+    @Override
+    public int hashCode() {
+      return type.hashCode();
+    }
+
+    @Override
+    public TypeKind getKind() {
+      return TypeKind.INTERSECTION;
+    }
+
+    @Override
+    public <R, P> R accept(TypeVisitor<R, P> v, P p) {
+      return v.visitIntersection(this, p);
+    }
+
+    final Supplier<ImmutableList<TypeMirror>> bounds =
+        factory.memoize(
+            new Supplier<ImmutableList<TypeMirror>>() {
+              @Override
+              public ImmutableList<TypeMirror> get() {
+                return factory.asTypeMirrors(type.bounds());
+              }
+            });
+
+    @Override
+    public List<? extends TypeMirror> getBounds() {
+      return bounds.get();
+    }
+  }
+}

--- a/java/com/google/turbine/processing/TurbineTypes.java
+++ b/java/com/google/turbine/processing/TurbineTypes.java
@@ -1,0 +1,783 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.base.Verify.verify;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.turbine.binder.bound.TypeBoundClass;
+import com.google.turbine.binder.bound.TypeBoundClass.TyVarInfo;
+import com.google.turbine.binder.sym.ClassSymbol;
+import com.google.turbine.binder.sym.TyVarSymbol;
+import com.google.turbine.model.TurbineConstantTypeKind;
+import com.google.turbine.type.Type;
+import com.google.turbine.type.Type.ArrayTy;
+import com.google.turbine.type.Type.ClassTy;
+import com.google.turbine.type.Type.ClassTy.SimpleClassTy;
+import com.google.turbine.type.Type.IntersectionTy;
+import com.google.turbine.type.Type.PrimTy;
+import com.google.turbine.type.Type.TyKind;
+import com.google.turbine.type.Type.TyVar;
+import com.google.turbine.type.Type.WildTy;
+import com.google.turbine.type.Type.WildTy.BoundKind;
+import com.google.turbine.types.Erasure;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ExecutableType;
+import javax.lang.model.type.NoType;
+import javax.lang.model.type.NullType;
+import javax.lang.model.type.PrimitiveType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.WildcardType;
+import javax.lang.model.util.Types;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/** An implementation of {@link Types} backed by turbine's implementation of {@link TypeMirror}. */
+public class TurbineTypes implements Types {
+
+  private final ModelFactory factory;
+
+  public TurbineTypes(ModelFactory factory) {
+    this.factory = factory;
+  }
+
+  private static Type asTurbineType(TypeMirror typeMirror) {
+    if (!(typeMirror instanceof TurbineTypeMirror)) {
+      throw new IllegalArgumentException(typeMirror.toString());
+    }
+    return ((TurbineTypeMirror) typeMirror).asTurbineType();
+  }
+
+  @Override
+  public Element asElement(TypeMirror t) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isSameType(TypeMirror a, TypeMirror b) {
+    Type t1 = asTurbineType(a);
+    Type t2 = asTurbineType(b);
+    if (t1.tyKind() == TyKind.WILD_TY || t2.tyKind() == TyKind.WILD_TY) {
+      // wild card types that appear at the top-level are never equal to each other.
+      // Note that generics parameterized by wildcards may be equal, so the recursive
+      // `isSameType(Type, Type)` below does handle wildcards.
+      return false;
+    }
+    return isSameType(t1, t2);
+  }
+
+  private static boolean isSameType(Type a, Type b) {
+    switch (a.tyKind()) {
+      case PRIM_TY:
+        return b.tyKind() == TyKind.PRIM_TY && ((PrimTy) a).primkind() == ((PrimTy) b).primkind();
+      case VOID_TY:
+        return b.tyKind() == TyKind.VOID_TY;
+      case NONE_TY:
+        return b.tyKind() == TyKind.NONE_TY;
+      case CLASS_TY:
+        return isSameClassType((ClassTy) a, b);
+      case ARRAY_TY:
+        return b.tyKind() == TyKind.ARRAY_TY
+            && isSameType(((ArrayTy) a).elementType(), ((ArrayTy) b).elementType());
+      case TY_VAR:
+        return b.tyKind() == TyKind.TY_VAR && ((TyVar) a).sym().equals(((TyVar) b).sym());
+      case WILD_TY:
+        return isSameWildType((WildTy) a, b);
+      case INTERSECTION_TY:
+        return b.tyKind() == TyKind.INTERSECTION_TY
+            && isSameIntersectionType((IntersectionTy) a, (IntersectionTy) b);
+      case ERROR_TY:
+        return false;
+    }
+    throw new AssertionError(a.tyKind());
+  }
+
+  private static boolean isSameTypes(ImmutableList<Type> a, ImmutableList<Type> b) {
+    if (a.size() != b.size()) {
+      return false;
+    }
+    Iterator<Type> ax = a.iterator();
+    Iterator<Type> bx = b.iterator();
+    while (ax.hasNext()) {
+      if (!isSameType(ax.next(), bx.next())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean isSameIntersectionType(IntersectionTy a, IntersectionTy b) {
+    return isSameTypes(a.bounds(), b.bounds());
+  }
+
+  private static boolean isSameWildType(WildTy a, Type other) {
+    switch (other.tyKind()) {
+      case WILD_TY:
+        break;
+      case CLASS_TY:
+        // `? super Object` = Object
+        return ((ClassTy) other).sym().equals(ClassSymbol.OBJECT)
+            && a.boundKind() == BoundKind.LOWER
+            && a.bound().tyKind() == TyKind.CLASS_TY
+            && ((ClassTy) a.bound()).sym().equals(ClassSymbol.OBJECT);
+      default:
+        return false;
+    }
+    WildTy b = (WildTy) other;
+    switch (a.boundKind()) {
+      case NONE:
+        switch (b.boundKind()) {
+          case UPPER:
+            // `?` = `? extends Object`
+            return isObjectType(b.bound());
+          case LOWER:
+            return false;
+          case NONE:
+            return true;
+        }
+        break;
+      case UPPER:
+        switch (b.boundKind()) {
+          case UPPER:
+            return isSameType(a.bound(), b.bound());
+          case LOWER:
+            return false;
+          case NONE:
+            // `? extends Object` = `?`
+            return isObjectType(a.bound());
+        }
+        break;
+      case LOWER:
+        return b.boundKind() == BoundKind.LOWER && isSameType(a.bound(), b.bound());
+    }
+    throw new AssertionError(a.boundKind());
+  }
+
+  private static boolean isSameClassType(ClassTy a, Type other) {
+    switch (other.tyKind()) {
+      case CLASS_TY:
+        break;
+      case WILD_TY:
+        WildTy w = (WildTy) other;
+        return a.sym().equals(ClassSymbol.OBJECT)
+            && w.boundKind() == BoundKind.LOWER
+            && w.bound().tyKind() == TyKind.CLASS_TY
+            && ((ClassTy) w.bound()).sym().equals(ClassSymbol.OBJECT);
+      default:
+        return false;
+    }
+    ClassTy b = (ClassTy) other;
+    if (!a.sym().equals(b.sym())) {
+      return false;
+    }
+    Iterator<SimpleClassTy> ax = a.classes().reverse().iterator();
+    Iterator<SimpleClassTy> bx = b.classes().reverse().iterator();
+    while (ax.hasNext() && bx.hasNext()) {
+      if (!isSameSimpleClassType(ax.next(), bx.next())) {
+        return false;
+      }
+    }
+    // The class type may be in non-canonical form, e.g. may or may not have entries in 'classes'
+    // corresponding to enclosing instances. Don't require the enclosing instances' representations
+    // to be identical unless one of them has type arguments.
+    if (hasTyArgs(ax) || hasTyArgs(bx)) {
+      return false;
+    }
+    return true;
+  }
+
+  /** Returns true if any {@link SimpleClassTy} in the given iterator has type arguments. */
+  private static boolean hasTyArgs(Iterator<SimpleClassTy> it) {
+    while (it.hasNext()) {
+      if (!it.next().targs().isEmpty()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isSameSimpleClassType(SimpleClassTy a, SimpleClassTy b) {
+    return a.sym().equals(b.sym()) && isSameTypes(a.targs(), b.targs());
+  }
+
+  /** Returns true if type {@code a} is a subtype of type {@code b}. See JLS 4.1.0, 'subtyping'. */
+  @Override
+  public boolean isSubtype(TypeMirror a, TypeMirror b) {
+    return isSubtype(asTurbineType(a), asTurbineType(b), /* strict= */ true);
+  }
+
+  /**
+   * Returns true if type {@code a} is a subtype of type {@code b}. See JLS 4.1.0, 'subtyping'.
+   *
+   * @param strict true if raw types should not be considered subtypes of parameterized types. See
+   *     also {@link #isAssignable}, which sets {@code strict} to {@code false} to handle unchecked
+   *     conversions.
+   */
+  private boolean isSubtype(Type a, Type b, boolean strict) {
+    if (b.tyKind() == TyKind.INTERSECTION_TY) {
+      for (Type bound : ((IntersectionTy) b).bounds()) {
+        // TODO(cushon): javac rejects e.g. `|List| isAssignable Serializable&ArrayList<?>`,
+        //  i.e. it does a strict subtype test against the intersection type. Is that a bug?
+        if (!isSubtype(a, bound, /* strict= */ true)) {
+          return false;
+        }
+      }
+      return true;
+    }
+    switch (a.tyKind()) {
+      case CLASS_TY:
+        return isClassSubtype((ClassTy) a, b, strict);
+      case PRIM_TY:
+        return isPrimSubtype((PrimTy) a, b);
+      case ARRAY_TY:
+        return isArraySubtype((ArrayTy) a, b, strict);
+      case TY_VAR:
+        return isTyVarSubtype((TyVar) a, b, strict);
+      case INTERSECTION_TY:
+        return isIntersectionSubtype((IntersectionTy) a, b, strict);
+      case VOID_TY:
+        return b.tyKind() == TyKind.VOID_TY;
+      case NONE_TY:
+        return b.tyKind() == TyKind.NONE_TY;
+      case WILD_TY:
+        // TODO(cushon): javac takes wildcards as input to isSubtype and sometimes returns `true`,
+        // see JDK-8039198
+        return false;
+      case ERROR_TY:
+        // for compatibility with javac, treat error as bottom
+        return true;
+    }
+    throw new AssertionError(a.tyKind());
+  }
+
+  private boolean isTyVarSubtype(TyVar a, Type b, boolean strict) {
+    if (b.tyKind() == TyKind.TY_VAR) {
+      return a.sym().equals(((TyVar) b).sym());
+    }
+    TyVarInfo tyVarInfo = factory.getTyVarInfo(a.sym());
+    return isSubtype(tyVarInfo.upperBound(), b, strict);
+  }
+
+  private boolean isIntersectionSubtype(IntersectionTy a, Type b, boolean strict) {
+    for (Type bound : a.bounds()) {
+      if (isSubtype(bound, b, strict)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // see JLS 4.10.3, 'subtyping among array types'
+  // https://docs.oracle.com/javase/specs/jls/se11/html/jls-4.html#jls-4.10.3
+  private boolean isArraySubtype(ArrayTy a, Type b, boolean strict) {
+    switch (b.tyKind()) {
+      case ARRAY_TY:
+        Type ae = a.elementType();
+        Type be = ((ArrayTy) b).elementType();
+        if (ae.tyKind() == TyKind.PRIM_TY) {
+          return isSameType(ae, be);
+        }
+        return isSubtype(ae, be, strict);
+      case CLASS_TY:
+        ClassSymbol bsym = ((ClassTy) b).sym();
+        switch (bsym.binaryName()) {
+          case "java/lang/Object":
+          case "java/lang/Cloneable":
+          case "java/io/Serializable":
+            return true;
+          default:
+            return false;
+        }
+      default:
+        return false;
+    }
+  }
+
+  // see JLS 4.10.1, 'subtyping among primitive types'
+  // https://docs.oracle.com/javase/specs/jls/se11/html/jls-4.html#jls-4.10.1
+  private static boolean isPrimSubtype(PrimTy a, Type other) {
+    if (other.tyKind() != TyKind.PRIM_TY) {
+      return false;
+    }
+    PrimTy b = (PrimTy) other;
+    switch (a.primkind()) {
+      case CHAR:
+        switch (b.primkind()) {
+          case CHAR:
+          case INT:
+          case LONG:
+          case FLOAT:
+          case DOUBLE:
+            return true;
+          default:
+            return false;
+        }
+      case BYTE:
+        switch (b.primkind()) {
+          case BYTE:
+          case SHORT:
+          case INT:
+          case LONG:
+          case FLOAT:
+          case DOUBLE:
+            return true;
+          default:
+            return false;
+        }
+      case SHORT:
+        switch (b.primkind()) {
+          case SHORT:
+          case INT:
+          case LONG:
+          case FLOAT:
+          case DOUBLE:
+            return true;
+          default:
+            return false;
+        }
+      case INT:
+        switch (b.primkind()) {
+          case INT:
+          case LONG:
+          case FLOAT:
+          case DOUBLE:
+            return true;
+          default:
+            return false;
+        }
+      case LONG:
+        switch (b.primkind()) {
+          case LONG:
+          case FLOAT:
+          case DOUBLE:
+            return true;
+          default:
+            return false;
+        }
+      case FLOAT:
+        switch (b.primkind()) {
+          case FLOAT:
+          case DOUBLE:
+            return true;
+          default:
+            return false;
+        }
+      case DOUBLE:
+      case STRING:
+      case BOOLEAN:
+        return a.primkind() == b.primkind();
+      case NULL:
+        break;
+    }
+    throw new AssertionError(a.primkind());
+  }
+
+  private boolean isClassSubtype(ClassTy a, Type other, boolean strict) {
+    if (other.tyKind() != TyKind.CLASS_TY) {
+      return false;
+    }
+    ClassTy b = (ClassTy) other;
+    if (!a.sym().equals(b.sym())) {
+      // find a path from a to b in the type hierarchy
+      ImmutableList<ClassTy> path = factory.cha().search(a, b.sym());
+      if (path.isEmpty()) {
+        return false;
+      }
+      // perform repeated type substitution to get an instance of B with the type arguments
+      // provided by A
+      a = path.get(0);
+      for (ClassTy ty : path) {
+        ImmutableMap<TyVarSymbol, Type> mapping = getMapping(ty);
+        if (mapping == null) {
+          // if we encounter a raw type on the path from A to B the result is erased
+          a = (ClassTy) erasure(a);
+          break;
+        }
+        a = substClassTy(a, mapping);
+      }
+    }
+    Iterator<SimpleClassTy> ax = a.classes().reverse().iterator();
+    Iterator<SimpleClassTy> bx = b.classes().reverse().iterator();
+    while (ax.hasNext() && bx.hasNext()) {
+      if (!tyArgsContains(ax.next(), bx.next(), strict)) {
+        return false;
+      }
+    }
+    return !hasTyArgs(ax) && !hasTyArgs(bx);
+  }
+
+  /**
+   * Given two parameterizations of the same {@link SimpleClassTy}, {@code a} and {@code b}, teturns
+   * true if the type arguments of {@code a} are pairwise contained by the type arguments of {@code
+   * b}.
+   *
+   * @see {@link #contains} and JLS 4.5.1.
+   */
+  private boolean tyArgsContains(SimpleClassTy a, SimpleClassTy b, boolean strict) {
+    verify(a.sym().equals(b.sym()));
+    Iterator<Type> ax = a.targs().iterator();
+    Iterator<Type> bx = b.targs().iterator();
+    while (ax.hasNext() && bx.hasNext()) {
+      if (!containedBy(ax.next(), bx.next(), strict)) {
+        return false;
+      }
+    }
+    // C<F1, ..., FN> <= |C|, but |C| is not a subtype of C<F1, ..., FN>
+    // https://docs.oracle.com/javase/specs/jls/se11/html/jls-4.html#jls-4.8
+    if (strict) {
+      return !bx.hasNext();
+    }
+    return true;
+  }
+
+  private static Type subst(Type type, Map<TyVarSymbol, Type> mapping) {
+    switch (type.tyKind()) {
+      case CLASS_TY:
+        return substClassTy((ClassTy) type, mapping);
+      case ARRAY_TY:
+        return substArrayTy((ArrayTy) type, mapping);
+      case TY_VAR:
+        return substTyVar((TyVar) type, mapping);
+      case WILD_TY:
+      case INTERSECTION_TY:
+      case PRIM_TY:
+      case VOID_TY:
+      case NONE_TY:
+      case ERROR_TY:
+        return type;
+    }
+    throw new AssertionError(type.tyKind());
+  }
+
+  private static Type substTyVar(TyVar type, Map<TyVarSymbol, Type> mapping) {
+    return mapping.getOrDefault(type.sym(), type);
+  }
+
+  private static Type substArrayTy(ArrayTy type, Map<TyVarSymbol, Type> mapping) {
+    return ArrayTy.create(subst(type.elementType(), mapping), type.annos());
+  }
+
+  private static ClassTy substClassTy(ClassTy type, Map<TyVarSymbol, Type> mapping) {
+    ImmutableList.Builder<SimpleClassTy> simples = ImmutableList.builder();
+    for (SimpleClassTy simple : type.classes()) {
+      ImmutableList.Builder<Type> args = ImmutableList.builder();
+      for (Type arg : simple.targs()) {
+        args.add(subst(arg, mapping));
+      }
+      simples.add(SimpleClassTy.create(simple.sym(), args.build(), simple.annos()));
+    }
+    return ClassTy.create(simples.build());
+  }
+
+  /**
+   * Returns a map from formal type parameters to their arguments for a given class type, or an
+   * empty map for non-parameterized types, or {@code null} for raw types.
+   */
+  @Nullable
+  private ImmutableMap<TyVarSymbol, Type> getMapping(ClassTy ty) {
+    ImmutableMap.Builder<TyVarSymbol, Type> mapping = ImmutableMap.builder();
+    for (SimpleClassTy s : ty.classes()) {
+      TypeBoundClass info = factory.getSymbol(s.sym());
+      if (s.targs().isEmpty() && !info.typeParameters().isEmpty()) {
+        return null; // rawtypes
+      }
+      Iterator<TyVarSymbol> ax = info.typeParameters().values().iterator();
+      Iterator<Type> bx = s.targs().iterator();
+      while (ax.hasNext()) {
+        mapping.put(ax.next(), bx.next());
+      }
+      verify(!bx.hasNext());
+    }
+    return mapping.build();
+  }
+
+  @Override
+  public boolean isAssignable(TypeMirror a1, TypeMirror a2) {
+    return isAssignable(asTurbineType(a1), asTurbineType(a2));
+  }
+
+  private boolean isAssignable(Type t1, Type t2) {
+    switch (t1.tyKind()) {
+      case PRIM_TY:
+        if (t2.tyKind() == TyKind.CLASS_TY) {
+          ClassSymbol boxed = boxedClass(((PrimTy) t1).primkind());
+          t1 = ClassTy.asNonParametricClassTy(boxed);
+        }
+        break;
+      case CLASS_TY:
+        switch (t2.tyKind()) {
+          case PRIM_TY:
+            TurbineConstantTypeKind unboxed = unboxedType((ClassTy) t1);
+            if (unboxed == null) {
+              return false;
+            }
+            t1 = PrimTy.create(unboxed, ImmutableList.of());
+            break;
+          case CLASS_TY:
+            break;
+          default: // fall out
+        }
+        break;
+      default: // fall out
+    }
+    return isSubtype(t1, t2, /* strict= */ false);
+  }
+
+  private static boolean isObjectType(Type type) {
+    return type.tyKind() == TyKind.CLASS_TY && ((ClassTy) type).sym().equals(ClassSymbol.OBJECT);
+  }
+
+  @Override
+  public boolean contains(TypeMirror a, TypeMirror b) {
+    return contains(asTurbineType(a), asTurbineType(b), /* strict= */ true);
+  }
+
+  private boolean contains(Type t1, Type t2, boolean strict) {
+    return containedBy(t2, t1, strict);
+  }
+
+  // See JLS 4.5.1, 'type containment'
+  // https://docs.oracle.com/javase/specs/jls/se11/html/jls-4.html#jls-4.5.1
+  private boolean containedBy(Type t1, Type t2, boolean strict) {
+    if (t1.tyKind() == TyKind.WILD_TY) {
+      WildTy w1 = (WildTy) t1;
+      Type t;
+      switch (w1.boundKind()) {
+        case UPPER:
+          t = w1.bound();
+          if (t2.tyKind() == TyKind.WILD_TY) {
+            WildTy w2 = (WildTy) t2;
+            switch (w2.boundKind()) {
+              case UPPER:
+                // ? extends T <= ? extends S if T <: S
+                return isSubtype(t, w2.bound(), strict);
+              case NONE:
+                // ? extends T <= ? [extends Object] if T <: Object
+                return true;
+              case LOWER:
+                // ? extends T <= ? super S
+                return false;
+            }
+            throw new AssertionError(w1.boundKind());
+          }
+          return false;
+        case LOWER:
+          t = w1.bound();
+          if (t2.tyKind() == TyKind.WILD_TY) {
+            WildTy w2 = (WildTy) t2;
+            switch (w2.boundKind()) {
+              case LOWER:
+                // ? super T <= ? super S if S <: T
+                return isSubtype(w2.bound(), t, strict);
+              case NONE:
+                // ? super T <= ? [extends Object]
+                return true;
+              case UPPER:
+                // ? super T <= ? extends Object
+                return isObjectType(w2.bound());
+            }
+            throw new AssertionError(w2.boundKind());
+          }
+          // ? super Object <= Object
+          return isObjectType(t2) && isObjectType(t);
+        case NONE:
+          if (t2.tyKind() == TyKind.WILD_TY) {
+            WildTy w2 = (WildTy) t2;
+            switch (w2.boundKind()) {
+              case NONE:
+                // ? [extends Object] <= ? extends Object
+                return true;
+              case LOWER:
+                // ? [extends Object] <= ? super S
+                return false;
+              case UPPER:
+                // ? [extends Object] <= ? extends S if Object <: S
+                return isObjectType(w2.bound());
+            }
+            throw new AssertionError(w2.boundKind());
+          }
+          return false;
+      }
+      throw new AssertionError(w1.boundKind());
+    }
+    if (t2.tyKind() == TyKind.WILD_TY) {
+      WildTy w2 = (WildTy) t2;
+      switch (w2.boundKind()) {
+        case LOWER:
+          // T <= ? super S
+          return isSubtype(w2.bound(), t1, strict);
+        case UPPER:
+          // T <= ? extends S
+          return isSubtype(t1, w2.bound(), strict);
+        case NONE:
+          // T <= ? [extends Object]
+          return true;
+      }
+      throw new AssertionError(w2.boundKind());
+    }
+    if (isSameType(t1, t2)) {
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public boolean isSubsignature(ExecutableType m1, ExecutableType m2) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public List<? extends TypeMirror> directSupertypes(TypeMirror m) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public TypeMirror erasure(TypeMirror typeMirror) {
+    return factory.asTypeMirror(erasure(asTurbineType(typeMirror)));
+  }
+
+  private Type erasure(Type type) {
+    return Erasure.erase(
+        type,
+        new Function<TyVarSymbol, TyVarInfo>() {
+          @Override
+          public TyVarInfo apply(TyVarSymbol input) {
+            return factory.getTyVarInfo(input);
+          }
+        });
+  }
+
+  @Override
+  public TypeElement boxedClass(PrimitiveType p) {
+    return factory.typeElement(boxedClass(((PrimTy) asTurbineType(p)).primkind()));
+  }
+
+  static ClassSymbol boxedClass(TurbineConstantTypeKind kind) {
+    switch (kind) {
+      case CHAR:
+        return ClassSymbol.CHARACTER;
+      case SHORT:
+        return ClassSymbol.SHORT;
+      case INT:
+        return ClassSymbol.INTEGER;
+      case LONG:
+        return ClassSymbol.LONG;
+      case FLOAT:
+        return ClassSymbol.FLOAT;
+      case DOUBLE:
+        return ClassSymbol.DOUBLE;
+      case BOOLEAN:
+        return ClassSymbol.BOOLEAN;
+      case BYTE:
+        return ClassSymbol.BYTE;
+      case STRING:
+      case NULL:
+        break;
+    }
+    throw new AssertionError(kind);
+  }
+
+  @Override
+  public PrimitiveType unboxedType(TypeMirror typeMirror) {
+    Type type = asTurbineType(typeMirror);
+    if (type.tyKind() != TyKind.CLASS_TY) {
+      throw new IllegalArgumentException(type.toString());
+    }
+    TurbineConstantTypeKind unboxed = unboxedType((ClassTy) type);
+    if (unboxed == null) {
+      throw new IllegalArgumentException(type.toString());
+    }
+    return (PrimitiveType) factory.asTypeMirror(PrimTy.create(unboxed, ImmutableList.of()));
+  }
+
+  private static TurbineConstantTypeKind unboxedType(ClassTy classTy) {
+    switch (classTy.sym().binaryName()) {
+      case "java/lang/Boolean":
+        return TurbineConstantTypeKind.BOOLEAN;
+      case "java/lang/Byte":
+        return TurbineConstantTypeKind.BYTE;
+      case "java/lang/Short":
+        return TurbineConstantTypeKind.SHORT;
+      case "java/lang/Integer":
+        return TurbineConstantTypeKind.INT;
+      case "java/lang/Long":
+        return TurbineConstantTypeKind.LONG;
+      case "java/lang/Character":
+        return TurbineConstantTypeKind.CHAR;
+      case "java/lang/Float":
+        return TurbineConstantTypeKind.FLOAT;
+      case "java/lang/Double":
+        return TurbineConstantTypeKind.DOUBLE;
+      default:
+        return null;
+    }
+  }
+
+  @Override
+  public TypeMirror capture(TypeMirror typeMirror) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public PrimitiveType getPrimitiveType(TypeKind kind) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public NullType getNullType() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public NoType getNoType(TypeKind kind) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ArrayType getArrayType(TypeMirror componentType) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public WildcardType getWildcardType(TypeMirror extendsBound, TypeMirror superBound) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public DeclaredType getDeclaredType(TypeElement typeElem, TypeMirror... typeArgs) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public DeclaredType getDeclaredType(
+      DeclaredType containing, TypeElement typeElem, TypeMirror... typeArgs) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public TypeMirror asMemberOf(DeclaredType containing, Element element) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/java/com/google/turbine/tree/Tree.java
+++ b/java/com/google/turbine/tree/Tree.java
@@ -661,6 +661,7 @@ public abstract class Tree {
     private final Tree ty;
     private final Ident name;
     private final Optional<Expression> init;
+    private final String javadoc;
 
     public VarDecl(
         int position,
@@ -668,13 +669,15 @@ public abstract class Tree {
         ImmutableList<Anno> annos,
         Tree ty,
         Ident name,
-        Optional<Expression> init) {
+        Optional<Expression> init,
+        String javadoc) {
       super(position);
       this.mods = ImmutableSet.copyOf(mods);
       this.annos = annos;
       this.ty = ty;
       this.name = name;
       this.init = init;
+      this.javadoc = javadoc;
     }
 
     @Override
@@ -706,6 +709,14 @@ public abstract class Tree {
     public Optional<Expression> init() {
       return init;
     }
+
+    /**
+     * A javadoc comment, excluding the opening and closing delimiters but including all interior
+     * characters and whitespace.
+     */
+    public String javadoc() {
+      return javadoc;
+    }
   }
 
   /** A JLS 8.4 method declaration. */
@@ -718,6 +729,7 @@ public abstract class Tree {
     private final ImmutableList<VarDecl> params;
     private final ImmutableList<ClassTy> exntys;
     private final Optional<Tree> defaultValue;
+    private final String javadoc;
 
     public MethDecl(
         int position,
@@ -728,7 +740,8 @@ public abstract class Tree {
         Ident name,
         ImmutableList<VarDecl> params,
         ImmutableList<ClassTy> exntys,
-        Optional<Tree> defaultValue) {
+        Optional<Tree> defaultValue,
+        String javadoc) {
       super(position);
       this.mods = ImmutableSet.copyOf(mods);
       this.annos = annos;
@@ -738,6 +751,7 @@ public abstract class Tree {
       this.params = params;
       this.exntys = exntys;
       this.defaultValue = defaultValue;
+      this.javadoc = javadoc;
     }
 
     @Override
@@ -780,6 +794,13 @@ public abstract class Tree {
 
     public Optional<Tree> defaultValue() {
       return defaultValue;
+    }
+    /**
+     * A javadoc comment, excluding the opening and closing delimiters but including all interior
+     * characters and whitespace.
+     */
+    public String javadoc() {
+      return javadoc;
     }
   }
 
@@ -852,6 +873,7 @@ public abstract class Tree {
     private final ImmutableList<ClassTy> impls;
     private final ImmutableList<Tree> members;
     private final TurbineTyKind tykind;
+    private final String javadoc;
 
     public TyDecl(
         int position,
@@ -862,7 +884,8 @@ public abstract class Tree {
         Optional<ClassTy> xtnds,
         ImmutableList<ClassTy> impls,
         ImmutableList<Tree> members,
-        TurbineTyKind tykind) {
+        TurbineTyKind tykind,
+        String javadoc) {
       super(position);
       this.mods = ImmutableSet.copyOf(mods);
       this.annos = annos;
@@ -872,6 +895,7 @@ public abstract class Tree {
       this.impls = impls;
       this.members = members;
       this.tykind = tykind;
+      this.javadoc = javadoc;
     }
 
     @Override
@@ -914,6 +938,13 @@ public abstract class Tree {
 
     public TurbineTyKind tykind() {
       return tykind;
+    }
+    /**
+     * A javadoc comment, excluding the opening and closing delimiters but including all interior
+     * characters and whitespace.
+     */
+    public String javadoc() {
+      return javadoc;
     }
   }
 

--- a/java/com/google/turbine/type/Type.java
+++ b/java/com/google/turbine/type/Type.java
@@ -52,7 +52,8 @@ public interface Type {
     /** An intersection type. */
     INTERSECTION_TY,
 
-    ERROR_TY
+    ERROR_TY,
+    NONE_TY,
   }
 
   /** The type kind. */
@@ -72,7 +73,27 @@ public interface Type {
         }
       };
 
-  /** A class type. */
+  /** The void type. */
+  Type NONE =
+      new Type() {
+        @Override
+        public TyKind tyKind() {
+          return TyKind.NONE_TY;
+        }
+
+        @Override
+        public final String toString() {
+          return "none";
+        }
+      };
+
+  /**
+   * A class type.
+   *
+   * <p>Qualified types (e.g. {@code OuterClass<Foo>.InnerClass<Bar>}) are repesented as a list
+   * {@link SimpleClassTy}s (enclosing types first), each of which contains a {@link ClassSymbol}
+   * and an optional list of type arguments.
+   */
   @AutoValue
   abstract class ClassTy implements Type {
 
@@ -87,17 +108,12 @@ public interface Type {
 
     /** Returns a {@link ClassTy} with no type arguments for the given {@link ClassSymbol}. */
     public static ClassTy asNonParametricClassTy(ClassSymbol i) {
-      return create(Arrays.asList(SimpleClassTy.create(i, ImmutableList.of(), ImmutableList.of())));
+      return ClassTy.create(
+          Arrays.asList(SimpleClassTy.create(i, ImmutableList.of(), ImmutableList.of())));
     }
 
     public abstract ImmutableList<SimpleClassTy> classes();
 
-    /**
-     * A class type. Qualified types are repesented as a list tuples, each of which contains a
-     * {@link ClassSymbol} and an optional list of type arguments.
-     *
-     * @param classes components of a qualified class type, possibly with type arguments.
-     */
     public static ClassTy create(Iterable<SimpleClassTy> classes) {
       return new AutoValue_Type_ClassTy(ImmutableList.copyOf(classes));
     }
@@ -448,7 +464,7 @@ public interface Type {
 
     @Override
     public final String toString() {
-      return Joiner.on(" $ ").join(bounds());
+      return Joiner.on('&').join(bounds());
     }
   }
 

--- a/java/com/google/turbine/type/Type.java
+++ b/java/com/google/turbine/type/Type.java
@@ -445,6 +445,11 @@ public interface Type {
     @Memoized
     @Override
     public abstract int hashCode();
+
+    @Override
+    public final String toString() {
+      return Joiner.on(" $ ").join(bounds());
+    }
   }
 
   /** An error type. */

--- a/javatests/com/google/turbine/model/ConstTest.java
+++ b/javatests/com/google/turbine/model/ConstTest.java
@@ -129,6 +129,9 @@ public class ConstTest {
         .isEqualTo("@p.Anno(xs={1})");
     assertThat(makeAnno(ImmutableMap.of("x", new IntValue(1), "y", new IntValue(2))))
         .isEqualTo("@p.Anno(x=1, y=2)");
+    assertThat(new Const.StringValue("\"").toString()).isEqualTo("\"\\\"\"");
+    assertThat(new Const.ByteValue((byte) 42).toString()).isEqualTo("(byte)0x2a");
+    assertThat(new Const.ShortValue((short) 42).toString()).isEqualTo("(short)42");
   }
 
   private static String makeAnno(ImmutableMap<String, Const> value) {

--- a/javatests/com/google/turbine/parse/CommentParserTest.java
+++ b/javatests/com/google/turbine/parse/CommentParserTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.parse;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.base.Joiner;
+import com.google.turbine.tree.Tree;
+import com.google.turbine.tree.Tree.MethDecl;
+import com.google.turbine.tree.Tree.TyDecl;
+import com.google.turbine.tree.Tree.VarDecl;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class CommentParserTest {
+
+  @Test
+  public void comments() {
+    Tree.CompUnit unit =
+        Parser.parse(
+            Joiner.on('\n')
+                .join(
+                    "package p;",
+                    "/** hello world */",
+                    "class Test {",
+                    "  /**",
+                    "   * This is",
+                    "   * class A",
+                    "   */",
+                    "  class A {",
+                    "    /** This is a method */",
+                    "    void f() {}",
+                    "    /** This is a field */",
+                    "    int g;",
+                    "  }",
+                    "  /* This is not javadoc */",
+                    "  class B {}",
+                    "  /**",
+                    "   * This is",
+                    "   * class C",
+                    "   */",
+                    "  class C {}",
+                    "}\n"));
+    TyDecl decl = getOnlyElement(unit.decls());
+    assertThat(decl.javadoc()).isEqualTo(" hello world ");
+    assertThat(
+            decl.members().stream()
+                .map(Tree.TyDecl.class::cast)
+                .filter(c -> c.javadoc() != null)
+                .collect(toImmutableMap(c -> c.name().value(), c -> c.javadoc())))
+        .containsExactly(
+            "A", "\n   * This is\n   * class A\n   ",
+            "C", "\n   * This is\n   * class C\n   ");
+    TyDecl a = (TyDecl) decl.members().get(0);
+    MethDecl f = (MethDecl) a.members().get(0);
+    assertThat(f.javadoc()).isEqualTo(" This is a method ");
+    VarDecl g = (VarDecl) a.members().get(1);
+    assertThat(g.javadoc()).isEqualTo(" This is a field ");
+  }
+}

--- a/javatests/com/google/turbine/processing/AbstractTurbineTypesBiPredicateTest.java
+++ b/javatests/com/google/turbine/processing/AbstractTurbineTypesBiPredicateTest.java
@@ -40,7 +40,7 @@ abstract class AbstractTurbineTypesBiPredicateTest extends AbstractTurbineTypesT
 
   protected void test(String symbol, TypeBiPredicate predicate) {
     assertWithMessage("%s = %s", javacInput.format(symbol), turbineInput.format(symbol))
-        .that(javacInput.apply(predicate))
-        .isEqualTo(turbineInput.apply(predicate));
+        .that(turbineInput.apply(predicate))
+        .isEqualTo(javacInput.apply(predicate));
   }
 }

--- a/javatests/com/google/turbine/processing/AbstractTurbineTypesBiPredicateTest.java
+++ b/javatests/com/google/turbine/processing/AbstractTurbineTypesBiPredicateTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Types;
+
+/**
+ * A combo test for {@link TurbineTypes} that compares the behaviour of bipredicates like {@link
+ * Types#isSubtype(TypeMirror, TypeMirror)} with javac's implementation.
+ */
+abstract class AbstractTurbineTypesBiPredicateTest extends AbstractTurbineTypesTest {
+
+  final String testDescription;
+  final TypesBiFunctionInput javacInput;
+  final TypesBiFunctionInput turbineInput;
+
+  public AbstractTurbineTypesBiPredicateTest(
+      String testDescription, TypesBiFunctionInput javacInput, TypesBiFunctionInput turbineInput) {
+    this.testDescription = testDescription;
+    this.javacInput = javacInput;
+    this.turbineInput = turbineInput;
+  }
+
+  protected void test(String symbol, TypeBiPredicate predicate) {
+    assertWithMessage("%s = %s", javacInput.format(symbol), turbineInput.format(symbol))
+        .that(javacInput.apply(predicate))
+        .isEqualTo(turbineInput.apply(predicate));
+  }
+}

--- a/javatests/com/google/turbine/processing/AbstractTurbineTypesTest.java
+++ b/javatests/com/google/turbine/processing/AbstractTurbineTypesTest.java
@@ -253,6 +253,7 @@ class AbstractTurbineTypesTest {
       String content = sb.toString();
       files.add(content);
     }
+    // type hierarchies
     files.add(
         Joiner.on('\n')
             .join(
@@ -292,6 +293,37 @@ class AbstractTurbineTypesTest {
                 "  F<Object> f3;",
                 "  G<Integer> g1;",
                 "  G<Number> g2;",
+                "}"));
+    // methods
+    files.add(
+        Joiner.on('\n')
+            .join(
+                "import java.io.*;",
+                "class Methods {",
+                " void f() {}",
+                " void g() {}",
+                " void f(int x) {}",
+                " void f(int x, int y) {}",
+                "  abstract static class I {",
+                "    abstract int f();",
+                "    abstract void g() throws IOException;",
+                "    abstract <T> void h();",
+                "    abstract <T extends String> T i(T s);",
+                "  }",
+                "  abstract static class J {",
+                "    abstract long f();",
+                "    abstract void g();",
+                "    abstract <T> void h();",
+                "    abstract <T extends Number> T i(T s);",
+                "  }",
+                "  class K {",
+                "    void f(K this, int x) {}",
+                "    void g(K this) {}",
+                "  }",
+                "  class L {",
+                "    void f(int x) {}",
+                "    void g() {}",
+                "  }",
                 "}"));
 
     Context context = new Context();
@@ -457,6 +489,7 @@ class AbstractTurbineTypesTest {
           public Void visitExecutable(ExecutableElement e, Void unused) {
             scan(e.getTypeParameters(), null);
             scan(e.getParameters(), null);
+            addType(e, e.asType());
             addType(e, e.getReturnType());
             addType(e, e.getReceiverType());
             addType(e, e.getThrownTypes());

--- a/javatests/com/google/turbine/processing/AbstractTurbineTypesTest.java
+++ b/javatests/com/google/turbine/processing/AbstractTurbineTypesTest.java
@@ -1,0 +1,475 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.joining;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
+import com.google.common.collect.Streams;
+import com.google.turbine.binder.Binder;
+import com.google.turbine.binder.Binder.BindingResult;
+import com.google.turbine.binder.ClassPathBinder;
+import com.google.turbine.binder.bound.TypeBoundClass;
+import com.google.turbine.binder.env.CompoundEnv;
+import com.google.turbine.binder.env.Env;
+import com.google.turbine.binder.env.SimpleEnv;
+import com.google.turbine.binder.sym.ClassSymbol;
+import com.google.turbine.parse.Parser;
+import com.google.turbine.testing.TestClassPaths;
+import com.google.turbine.tree.Tree.CompUnit;
+import com.sun.source.util.JavacTask;
+import com.sun.tools.javac.api.JavacTool;
+import com.sun.tools.javac.file.JavacFileManager;
+import com.sun.tools.javac.util.Context;
+import java.net.URI;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
+import javax.lang.model.type.WildcardType;
+import javax.lang.model.util.ElementScanner8;
+import javax.lang.model.util.SimpleTypeVisitor8;
+import javax.lang.model.util.Types;
+import javax.tools.JavaFileManager;
+import javax.tools.JavaFileObject.Kind;
+import javax.tools.SimpleJavaFileObject;
+
+class AbstractTurbineTypesTest {
+
+  protected static class TypeParameters {
+    protected final Types javacTypes;
+    protected final List<List<TypeMirror>> aGroups;
+    protected final Types turbineTypes;
+    protected final List<List<TypeMirror>> bGroups;
+
+    private TypeParameters(
+        Types javacTypes,
+        List<List<TypeMirror>> aGroups,
+        Types turbineTypes,
+        List<List<TypeMirror>> bGroups) {
+      this.javacTypes = javacTypes;
+      this.aGroups = aGroups;
+      this.turbineTypes = turbineTypes;
+      this.bGroups = bGroups;
+    }
+  }
+
+  protected interface TypeBiPredicate {
+    boolean apply(Types types, TypeMirror a, TypeMirror b);
+  }
+
+  static class TypesBiFunctionInput {
+    final Types types;
+    final TypeMirror lhs;
+    final TypeMirror rhs;
+
+    TypesBiFunctionInput(Types types, TypeMirror lhs, TypeMirror rhs) {
+      this.types = types;
+      this.lhs = lhs;
+      this.rhs = rhs;
+    }
+
+    boolean apply(TypeBiPredicate predicate) {
+      return predicate.apply(types, lhs, rhs);
+    }
+
+    String format(String symbol) {
+      return String.format("`%s` %s `%s`", lhs, symbol, rhs);
+    }
+  }
+
+  protected static Iterable<Object[]> binaryParameters() throws Exception {
+    TypeParameters typeParameters = typeParameters();
+    List<Object[]> params = new ArrayList<>();
+    for (int i = 0; i < typeParameters.aGroups.size(); i++) {
+      List<TypeMirror> ax = typeParameters.aGroups.get(i);
+      List<TypeMirror> bx = typeParameters.bGroups.get(i);
+      Streams.zip(
+              Lists.cartesianProduct(ax, ax).stream(),
+              Lists.cartesianProduct(bx, bx).stream(),
+              (a, b) ->
+                  new Object[] {
+                    a.get(0) + " " + a.get(1),
+                    new TypesBiFunctionInput(typeParameters.javacTypes, a.get(0), a.get(1)),
+                    new TypesBiFunctionInput(typeParameters.turbineTypes, b.get(0), b.get(1)),
+                  })
+          .forEachOrdered(params::add);
+    }
+    return params;
+  }
+
+  protected static Iterable<Object[]> unaryParameters() throws Exception {
+    TypeParameters typeParameters = typeParameters();
+    List<Object[]> params = new ArrayList<>();
+    for (int i = 0; i < typeParameters.aGroups.size(); i++) {
+      Streams.zip(
+              typeParameters.aGroups.get(i).stream(),
+              typeParameters.bGroups.get(i).stream(),
+              (a, b) ->
+                  new Object[] {
+                    a.toString(), typeParameters.javacTypes, a, typeParameters.turbineTypes, b,
+                  })
+          .forEachOrdered(params::add);
+    }
+    return params;
+  }
+
+  protected static TypeParameters typeParameters() throws Exception {
+    String[][] types = {
+      // generics
+      {
+        "Object",
+        "String",
+        "Cloneable",
+        "Serializable",
+        "List",
+        "Set",
+        "ArrayList",
+        "Collection",
+        "List<Object>",
+        "List<Number>",
+        "List<Integer>",
+        "ArrayList<Object>",
+        "ArrayList<Number>",
+        "ArrayList<Integer>",
+      },
+      // wildcards
+      {
+        "Object",
+        "String",
+        "Cloneable",
+        "Serializable",
+        "List",
+        "List<?>",
+        "List<Object>",
+        "List<Number>",
+        "List<Integer>",
+        "List<? extends Object>",
+        "List<? extends Number>",
+        "List<? extends Integer>",
+        "List<? super Object>",
+        "List<? super Number>",
+        "List<? super Integer>",
+      },
+      // arrays
+      {
+        "Object",
+        "String",
+        "Cloneable",
+        "Serializable",
+        "List",
+        "Object[]",
+        "Number[]",
+        "List<Integer>[]",
+        "List<? extends Integer>[]",
+        "long[]",
+        "int[]",
+        "int[][]",
+        "Long[]",
+        "Integer[]",
+        "Integer[][]",
+      },
+      // primitives
+      {
+        "Object",
+        "String",
+        "Cloneable",
+        "Serializable",
+        "List",
+        "int",
+        "char",
+        "byte",
+        "short",
+        "boolean",
+        "long",
+        "float",
+        "double",
+        "Integer",
+        "Character",
+        "Byte",
+        "Short",
+        "Boolean",
+        "Long",
+        "Float",
+        "Double",
+      },
+    };
+    List<String> files = new ArrayList<>();
+    AtomicInteger idx = new AtomicInteger();
+    for (String[] group : types) {
+      StringBuilder sb = new StringBuilder();
+      Joiner.on('\n')
+          .appendTo(
+              sb,
+              "package p;",
+              "import java.util.*;",
+              "import java.io.*;",
+              String.format("abstract class Test%s {", idx.getAndIncrement()),
+              Streams.mapWithIndex(
+                      Arrays.stream(group), (x, i) -> String.format("  %s f%d;\n", x, i))
+                  .collect(joining("\n")),
+              "  abstract <T extends Serializable & List<T>> T f();",
+              "  abstract <V extends List<V>> V g();",
+              "  abstract <W extends ArrayList> W h();",
+              "  abstract <X extends Serializable> X i();",
+              "}");
+      String content = sb.toString();
+      files.add(content);
+    }
+    files.add(
+        Joiner.on('\n')
+            .join(
+                "import java.util.*;",
+                "class Hierarchy {", //
+                "  static class A<T> {",
+                "    class I {}",
+                "  }",
+                "  static class D<T> extends A<T[]> {}",
+                "  static class E<T> extends A<T> {",
+                "    class J extends I {}",
+                "  }",
+                "  static class F<T> extends A {}",
+                "  static class G<T> extends A<List<T>> {}",
+                "  A rawA;",
+                "  A<Object[]> a1;",
+                "  A<Number[]> a2;",
+                "  A<Integer[]> a3;",
+                "  A<? super Object> a4;",
+                "  A<? super Number> a5;",
+                "  A<? super Integer> a6;",
+                "  A<? extends Object> a7;",
+                "  A<? extends Number> a8;",
+                "  A<? extends Integer> a9;",
+                "  A<List<Integer>> a10;",
+                "  D<Object> d1;",
+                "  D<Number> d2;",
+                "  D<Integer> d3;",
+                "  A<Object>.I i1;",
+                "  A<Number>.I i2;",
+                "  A<Integer>.I i3;",
+                "  E<Object>.J j1;",
+                "  E<Number>.J j2;",
+                "  E<Integer>.J j3;",
+                "  F<Integer> f1;",
+                "  F<Number> f2;",
+                "  F<Object> f3;",
+                "  G<Integer> g1;",
+                "  G<Number> g2;",
+                "}"));
+
+    Context context = new Context();
+    JavaFileManager fileManager = new JavacFileManager(context, true, UTF_8);
+    idx.set(0);
+    ImmutableList<SimpleJavaFileObject> compilationUnits =
+        files.stream()
+            .map(
+                x ->
+                    new SimpleJavaFileObject(
+                        URI.create("file://test" + idx.getAndIncrement() + ".java"), Kind.SOURCE) {
+                      @Override
+                      public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+                        return x;
+                      }
+                    })
+            .collect(toImmutableList());
+    JavacTask task =
+        JavacTool.create()
+            .getTask(
+                /* out= */ null,
+                fileManager,
+                /* diagnosticListener= */ null,
+                /* options= */ ImmutableList.of(),
+                /* classes= */ ImmutableList.of(),
+                compilationUnits);
+
+    Types javacTypes = task.getTypes();
+    ImmutableMap<String, Element> javacElements =
+        Streams.stream(task.analyze())
+            .collect(toImmutableMap(e -> e.getSimpleName().toString(), x -> x));
+
+    ImmutableList<CompUnit> units = files.stream().map(Parser::parse).collect(toImmutableList());
+    BindingResult bound =
+        Binder.bind(
+            units,
+            ClassPathBinder.bindClasspath(ImmutableList.of()),
+            TestClassPaths.TURBINE_BOOTCLASSPATH,
+            Optional.empty());
+    Env<ClassSymbol, TypeBoundClass> env =
+        CompoundEnv.<ClassSymbol, TypeBoundClass>of(bound.classPathEnv())
+            .append(new SimpleEnv<>(bound.units()));
+    ModelFactory factory = new ModelFactory(env);
+    Types turbineTypes = new TurbineTypes(factory);
+    ImmutableMap<String, Element> turbineElements =
+        bound.units().keySet().stream()
+            .filter(x -> !x.binaryName().contains("$")) // only top level classes
+            .collect(toImmutableMap(x -> x.simpleName(), factory::element));
+
+    assertThat(javacElements.keySet()).containsExactlyElementsIn(turbineElements.keySet());
+
+    List<List<TypeMirror>> aGroups = new ArrayList<>();
+    List<List<TypeMirror>> bGroups = new ArrayList<>();
+    for (String name : javacElements.keySet()) {
+
+      List<TypeMirror> aGroup = new ArrayList<>();
+      List<TypeMirror> bGroup = new ArrayList<>();
+
+      ListMultimap<String, TypeMirror> javacInputs =
+          MultimapBuilder.linkedHashKeys().arrayListValues().build();
+      javacElements.get(name).getEnclosedElements().forEach(e -> getTypes(e, javacInputs));
+
+      ListMultimap<String, TypeMirror> turbineInputs =
+          MultimapBuilder.linkedHashKeys().arrayListValues().build();
+      turbineElements.get(name).getEnclosedElements().forEach(e -> getTypes(e, turbineInputs));
+
+      assertThat(turbineInputs.keySet()).containsExactlyElementsIn(javacInputs.keySet());
+
+      for (String key : javacInputs.keySet()) {
+        List<TypeMirror> a = javacInputs.get(key);
+        List<TypeMirror> b = turbineInputs.get(key);
+        assertWithMessage(key)
+            .that(b.stream().map(x -> x.getKind() + " " + x).collect(toImmutableList()))
+            .containsExactlyElementsIn(
+                a.stream().map(x -> x.getKind() + " " + x).collect(toImmutableList()))
+            .inOrder();
+        aGroup.addAll(a);
+        bGroup.addAll(b);
+      }
+      aGroups.add(aGroup);
+      bGroups.add(bGroup);
+    }
+    return new TypeParameters(javacTypes, aGroups, turbineTypes, bGroups);
+  }
+
+  /**
+   * Discover all types contained in the given element, keyed by their immediate enclosing element.
+   */
+  private static void getTypes(Element element, Multimap<String, TypeMirror> types) {
+    element.accept(
+        new ElementScanner8<Void, Void>() {
+
+          /**
+           * Returns an element name qualified by all enclosing elements, to allow comparison
+           * between javac and turbine's implementation to group related types.
+           */
+          String key(Element e) {
+            Deque<String> flat = new ArrayDeque<>();
+            while (e != null) {
+              flat.addFirst(e.getSimpleName().toString());
+              if (e.getKind() == ElementKind.PACKAGE) {
+                break;
+              }
+              e = e.getEnclosingElement();
+            }
+            return Joiner.on('.').join(flat);
+          }
+
+          void addType(Element e, TypeMirror t) {
+            if (t != null) {
+              types.put(key(e), t);
+              t.accept(
+                  new SimpleTypeVisitor8<Void, Void>() {
+                    @Override
+                    public Void visitDeclared(DeclaredType t, Void aVoid) {
+                      for (TypeMirror a : t.getTypeArguments()) {
+                        a.accept(this, null);
+                      }
+                      return null;
+                    }
+
+                    @Override
+                    public Void visitWildcard(WildcardType t, Void aVoid) {
+                      types.put(key(e), t);
+                      return null;
+                    }
+
+                    @Override
+                    public Void visitTypeVariable(TypeVariable t, Void aVoid) {
+                      if (t.getUpperBound() != null) {
+                        types.put(key(e), t.getUpperBound());
+                      }
+                      return null;
+                    }
+                  },
+                  null);
+            }
+          }
+
+          void addType(Element e, List<? extends TypeMirror> types) {
+            for (TypeMirror type : types) {
+              addType(e, type);
+            }
+          }
+
+          @Override
+          public Void visitVariable(VariableElement e, Void unused) {
+            if (e.getSimpleName().toString().contains("this$")) {
+              // enclosing instance parameters
+              return null;
+            }
+            addType(e, e.asType());
+            return super.visitVariable(e, null);
+          }
+
+          @Override
+          public Void visitType(TypeElement e, Void unused) {
+            addType(e, e.asType());
+            return super.visitType(e, null);
+          }
+
+          @Override
+          public Void visitExecutable(ExecutableElement e, Void unused) {
+            scan(e.getTypeParameters(), null);
+            scan(e.getParameters(), null);
+            addType(e, e.getReturnType());
+            addType(e, e.getReceiverType());
+            addType(e, e.getThrownTypes());
+            return null;
+          }
+
+          @Override
+          public Void visitTypeParameter(TypeParameterElement e, Void unused) {
+            addType(e, e.asType());
+            addType(e, e.getBounds());
+            return null;
+          }
+        },
+        null);
+  }
+}

--- a/javatests/com/google/turbine/processing/TurbineElementTest.java
+++ b/javatests/com/google/turbine/processing/TurbineElementTest.java
@@ -199,13 +199,9 @@ public class TurbineElementTest {
 
   @Test
   public void typeKind() {
-    assertThat(
-            ((TypeElement) factory.typeElement(new ClassSymbol("java/lang/annotation/Target")))
-                .getKind())
+    assertThat(factory.typeElement(new ClassSymbol("java/lang/annotation/Target")).getKind())
         .isEqualTo(ElementKind.ANNOTATION_TYPE);
-    assertThat(
-            ((TypeElement) factory.typeElement(new ClassSymbol("java/lang/annotation/ElementType")))
-                .getKind())
+    assertThat(factory.typeElement(new ClassSymbol("java/lang/annotation/ElementType")).getKind())
         .isEqualTo(ElementKind.ENUM);
   }
 
@@ -213,10 +209,9 @@ public class TurbineElementTest {
   public void parameter() {
     ExecutableElement equals =
         (ExecutableElement)
-            ((TypeElement) factory.typeElement(new ClassSymbol("java/lang/Object")))
-                .getEnclosedElements().stream()
-                    .filter(e -> e.getSimpleName().contentEquals("equals"))
-                    .collect(MoreCollectors.onlyElement());
+            factory.typeElement(new ClassSymbol("java/lang/Object")).getEnclosedElements().stream()
+                .filter(e -> e.getSimpleName().contentEquals("equals"))
+                .collect(MoreCollectors.onlyElement());
     VariableElement parameter = getOnlyElement(equals.getParameters());
     assertThat(parameter.getKind()).isEqualTo(ElementKind.PARAMETER);
     assertThat(parameter.asType().toString()).isEqualTo("java.lang.Object");

--- a/javatests/com/google/turbine/processing/TurbineElementTest.java
+++ b/javatests/com/google/turbine/processing/TurbineElementTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.MoreCollectors;
+import com.google.common.testing.EqualsTester;
+import com.google.turbine.binder.sym.ClassSymbol;
+import com.google.turbine.binder.sym.FieldSymbol;
+import com.google.turbine.binder.sym.PackageSymbol;
+import com.google.turbine.testing.TestClassPaths;
+import com.google.turbine.type.Type.ClassTy;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.NestingKind;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TurbineElementTest {
+
+  private final ModelFactory factory = new ModelFactory(TestClassPaths.TURBINE_BOOTCLASSPATH.env());
+
+  @Test
+  public void typeElement() {
+    TypeElement e = factory.typeElement(new ClassSymbol("java/util/Map$Entry"));
+    TypeElement m = (TypeElement) e.getEnclosingElement();
+    TypeMirror t = e.asType();
+
+    assertThat(e.getSimpleName().toString()).isEqualTo("Entry");
+    assertThat(e.getQualifiedName().toString()).isEqualTo("java.util.Map.Entry");
+    assertThat(e.toString()).isEqualTo("java.util.Map.Entry");
+    assertThat(e.asType().toString()).isEqualTo("java.util.Map.Entry<K,V>");
+    assertThat(e.getKind()).isEqualTo(ElementKind.INTERFACE);
+    assertThat(e.getNestingKind()).isEqualTo(NestingKind.MEMBER);
+    assertThat(e.getModifiers())
+        .containsExactly(Modifier.PUBLIC, Modifier.ABSTRACT, Modifier.STATIC);
+
+    assertThat(m.getSimpleName().toString()).isEqualTo("Map");
+    assertThat(m.getSuperclass().getKind()).isEqualTo(TypeKind.NONE);
+    assertThat(m.getQualifiedName().toString()).isEqualTo("java.util.Map");
+    assertThat(m.toString()).isEqualTo("java.util.Map");
+    assertThat(m.asType().toString()).isEqualTo("java.util.Map<K,V>");
+    assertThat(m.getNestingKind()).isEqualTo(NestingKind.TOP_LEVEL);
+    assertThat(m.getSuperclass().getKind()).isEqualTo(TypeKind.NONE);
+    assertThat(m.getEnclosingElement().getKind()).isEqualTo(ElementKind.PACKAGE);
+
+    assertThat(t.getKind()).isEqualTo(TypeKind.DECLARED);
+  }
+
+  @Test
+  public void superClass() {
+    TypeElement e = factory.typeElement(new ClassSymbol("java/util/HashMap"));
+    assertThat(
+            ((TypeElement) ((DeclaredType) e.getSuperclass()).asElement())
+                .getQualifiedName()
+                .toString())
+        .isEqualTo("java.util.AbstractMap");
+  }
+
+  @Test
+  public void interfaces() {
+    TypeElement e = factory.typeElement(new ClassSymbol("java/util/HashMap"));
+    assertThat(
+            e.getInterfaces().stream()
+                .map(
+                    i ->
+                        ((TypeElement) ((DeclaredType) i).asElement())
+                            .getQualifiedName()
+                            .toString())
+                .collect(toImmutableList()))
+        .contains("java.util.Map");
+  }
+
+  @Test
+  public void typeParameters() {
+    TypeElement e = factory.typeElement(new ClassSymbol("java/util/HashMap"));
+    assertThat(e.getTypeParameters().stream().map(Object::toString).collect(toImmutableList()))
+        .containsExactly("K", "V");
+    for (TypeParameterElement t : e.getTypeParameters()) {
+      assertThat(t.getGenericElement()).isEqualTo(e);
+      assertThat(t.getEnclosingElement()).isEqualTo(e);
+      assertThat(t.getBounds()).containsExactly(factory.asTypeMirror(ClassTy.OBJECT));
+    }
+  }
+
+  @Test
+  public void enclosed() {
+    assertThat(
+            factory.typeElement(new ClassSymbol("java/lang/Integer")).getEnclosedElements().stream()
+                .map(e -> e.getKind() + " " + e)
+                .collect(toImmutableList()))
+        .containsAtLeast("METHOD parseInt(java.lang.String)", "FIELD MAX_VALUE");
+  }
+
+  @Test
+  public void equals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            factory.typeElement(new ClassSymbol("java/util/List")),
+            factory.typeElement(new ClassSymbol("java/util/List")))
+        .addEqualityGroup(factory.typeElement(new ClassSymbol("java/util/ArrayList")))
+        .addEqualityGroup(
+            factory.typeElement(new ClassSymbol("java/util/Map")).getTypeParameters().get(0),
+            factory.typeElement(new ClassSymbol("java/util/Map")).getTypeParameters().get(0))
+        .addEqualityGroup(
+            factory.typeElement(new ClassSymbol("java/util/ArrayList")).getTypeParameters().get(0))
+        .addEqualityGroup(
+            factory.fieldElement(
+                new FieldSymbol(new ClassSymbol("java/util/ArrayList"), "elementData")),
+            factory.fieldElement(
+                new FieldSymbol(new ClassSymbol("java/util/ArrayList"), "elementData")))
+        .addEqualityGroup(
+            factory.fieldElement(
+                new FieldSymbol(new ClassSymbol("java/util/ArrayList"), "serialVersionUID")))
+        .addEqualityGroup(
+            ((ExecutableElement)
+                    factory
+                        .typeElement(new ClassSymbol("java/util/ArrayList"))
+                        .getEnclosedElements()
+                        .stream()
+                        .filter(
+                            e ->
+                                e.getKind().equals(ElementKind.METHOD)
+                                    && e.getSimpleName().contentEquals("add"))
+                        .skip(1)
+                        .findFirst()
+                        .get())
+                .getParameters()
+                .get(0))
+        .addEqualityGroup(
+            factory
+                .typeElement(new ClassSymbol("java/util/ArrayList"))
+                .getEnclosedElements()
+                .stream()
+                .filter(e -> e.getKind().equals(ElementKind.METHOD))
+                .skip(1)
+                .findFirst()
+                .get())
+        .addEqualityGroup(
+            factory
+                .typeElement(new ClassSymbol("java/util/ArrayList"))
+                .getEnclosedElements()
+                .stream()
+                .filter(e -> e.getKind().equals(ElementKind.METHOD))
+                .findFirst()
+                .get(),
+            factory
+                .typeElement(new ClassSymbol("java/util/ArrayList"))
+                .getEnclosedElements()
+                .stream()
+                .filter(e -> e.getKind().equals(ElementKind.METHOD))
+                .findFirst()
+                .get())
+        .addEqualityGroup(
+            factory.packageElement(new PackageSymbol("java/util")),
+            factory.typeElement(new ClassSymbol("java/util/ArrayList")).getEnclosingElement())
+        .addEqualityGroup(factory.packageElement(new PackageSymbol("java/lang")))
+        .testEquals();
+  }
+
+  @Test
+  public void noElement() {
+    PackageElement p = factory.packageElement(new PackageSymbol("java/lang"));
+    assertThat(p.getEnclosingElement()).isNull();
+  }
+
+  @Test
+  public void objectSuper() {
+    assertThat(factory.typeElement(new ClassSymbol("java/lang/Object")).getSuperclass().getKind())
+        .isEqualTo(TypeKind.NONE);
+  }
+
+  @Test
+  public void typeKind() {
+    assertThat(
+            ((TypeElement) factory.typeElement(new ClassSymbol("java/lang/annotation/Target")))
+                .getKind())
+        .isEqualTo(ElementKind.ANNOTATION_TYPE);
+    assertThat(
+            ((TypeElement) factory.typeElement(new ClassSymbol("java/lang/annotation/ElementType")))
+                .getKind())
+        .isEqualTo(ElementKind.ENUM);
+  }
+
+  @Test
+  public void parameter() {
+    ExecutableElement equals =
+        (ExecutableElement)
+            ((TypeElement) factory.typeElement(new ClassSymbol("java/lang/Object")))
+                .getEnclosedElements().stream()
+                    .filter(e -> e.getSimpleName().contentEquals("equals"))
+                    .collect(MoreCollectors.onlyElement());
+    VariableElement parameter = getOnlyElement(equals.getParameters());
+    assertThat(parameter.getKind()).isEqualTo(ElementKind.PARAMETER);
+    assertThat(parameter.asType().toString()).isEqualTo("java.lang.Object");
+    assertThat(parameter.getModifiers()).isEmpty();
+    assertThat(parameter.getEnclosedElements()).isEmpty();
+    assertThat(parameter.getSimpleName().toString()).isNotEmpty();
+    assertThat(parameter.getConstantValue()).isNull();
+  }
+}

--- a/javatests/com/google/turbine/processing/TurbineElementsGetAllMembersTest.java
+++ b/javatests/com/google/turbine/processing/TurbineElementsGetAllMembersTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.turbine.binder.Binder;
+import com.google.turbine.binder.ClassPathBinder;
+import com.google.turbine.binder.bound.TypeBoundClass;
+import com.google.turbine.binder.env.CompoundEnv;
+import com.google.turbine.binder.env.Env;
+import com.google.turbine.binder.env.SimpleEnv;
+import com.google.turbine.binder.sym.ClassSymbol;
+import com.google.turbine.diag.SourceFile;
+import com.google.turbine.lower.IntegrationTestSupport;
+import com.google.turbine.lower.IntegrationTestSupport.TestInput;
+import com.google.turbine.parse.Parser;
+import com.google.turbine.testing.TestClassPaths;
+import com.google.turbine.tree.Tree.CompUnit;
+import com.sun.source.util.JavacTask;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import javax.lang.model.element.Element;
+import javax.lang.model.util.Elements;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class TurbineElementsGetAllMembersTest {
+
+  @Parameters
+  public static Iterable<Object[]> parameters() {
+    // An array of test inputs. Each element is an array of lines of sources to compile.
+    String[][] inputs = {
+      {
+        "=== Test.java ===", //
+        "class Test {",
+        "}",
+      },
+      {
+        "=== A.java ===",
+        "interface A {",
+        "  Integer f();",
+        "}",
+        "=== B.java ===",
+        "interface B {",
+        "  Integer f();",
+        "}",
+        "=== Test.java ===", //
+        "class Test implements A, B {",
+        "  Integer f() {",
+        "    return 42;",
+        "  }",
+        "}",
+      },
+      {
+        "=== I.java ===",
+        "abstract class I {",
+        "  abstract Integer f();",
+        "}",
+        "=== J.java ===",
+        "interface J extends I {",
+        "  default Integer f() {",
+        "    return 42;",
+        "  }",
+        "}",
+        "=== Test.java ===", //
+        "class Test extends I implements J {",
+        "}",
+      },
+      {
+        "=== I.java ===",
+        "interface I {",
+        "  Integer f();",
+        "}",
+        "=== J.java ===",
+        "interface J extends I {",
+        "  default Integer f() {",
+        "    return 42;",
+        "  }",
+        "}",
+        "=== Test.java ===", //
+        "class Test implements J, I {",
+        "}",
+      },
+      {
+        "=== p/A.java ===",
+        "package p;",
+        "public class A {",
+        "  public boolean f() {",
+        "    return true;",
+        "  }",
+        "}",
+        "=== p/B.java ===",
+        "package p;",
+        "public interface B {",
+        "  public boolean f();",
+        "}",
+        "=== Test.java ===", //
+        "import p.*;",
+        "class Test extends A implements B {",
+        "}",
+      },
+      {
+        "=== p/A.java ===",
+        "package p;",
+        "public class A {",
+        "  public boolean f() {",
+        "    return true;",
+        "  }",
+        "}",
+        "=== p/B.java ===",
+        "package p;",
+        "public interface B {",
+        "  public boolean f();",
+        "}",
+        "=== Middle.java ===", //
+        "import p.*;",
+        "public abstract class Middle extends A implements B {",
+        "}",
+        "=== Test.java ===", //
+        "class Test extends Middle {",
+        "}",
+      },
+      {
+        "=== A.java ===",
+        "interface A {",
+        "  Integer f();",
+        "}",
+        "=== B.java ===",
+        "interface B {",
+        "  Number f();",
+        "}",
+        "=== Test.java ===", //
+        "abstract class Test implements A, B {",
+        "}",
+      },
+      {
+        "=== A.java ===",
+        "interface A {",
+        "  Integer f();",
+        "}",
+        "=== B.java ===",
+        "interface B {",
+        "  Integer f();",
+        "}",
+        "=== Test.java ===", //
+        "abstract class Test implements A, B {",
+        "}",
+      },
+      {
+        "=== I.java ===",
+        "interface I {",
+        "  int x;",
+        "}",
+        "=== J.java ===",
+        "interface J {",
+        "  int x;",
+        "}",
+        "=== B.java ===",
+        "class B {",
+        "  int x;",
+        "}",
+        "=== C.java ===",
+        "class C extends B {",
+        "  static int x;",
+        "}",
+        "=== Test.java ===",
+        "class Test extends C implements I, J {",
+        "  int x;",
+        "}",
+      },
+      {
+        "=== one/A.java ===",
+        "public class A {",
+        "  int a;",
+        "}",
+        "=== two/B.java ===",
+        "public class B extends A {",
+        "  int b;",
+        "  private int c;",
+        "  protected int d;",
+        "}",
+        "=== Test.java ===",
+        "public class Test extends B {",
+        "  int x;",
+        "}",
+      },
+      {
+        "=== A.java ===",
+        "interface A {",
+        "  class I {}",
+        "}",
+        "=== B.java ===",
+        "interface B {",
+        "  class J {}",
+        "}",
+        "=== Test.java ===", //
+        "abstract class Test implements A, B {",
+        "}",
+      },
+    };
+    return Arrays.stream(inputs)
+        .map(input -> TestInput.parse(Joiner.on('\n').join(input)))
+        .map(x -> new Object[] {x})
+        .collect(toImmutableList());
+  }
+
+  private final TestInput input;
+
+  public TurbineElementsGetAllMembersTest(TestInput input) {
+    this.input = input;
+  }
+
+  // Compile the test inputs with javac and turbine, and assert that getAllMembers returns the
+  // same elements under each implementation.
+  @Test
+  public void test() throws Exception {
+    JavacTask javacTask =
+        IntegrationTestSupport.runJavacAnalysis(
+            input.sources, ImmutableList.of(), ImmutableList.of());
+    Elements javacElements = javacTask.getElements();
+    List<? extends Element> javacMembers =
+        javacElements.getAllMembers(requireNonNull(javacElements.getTypeElement("Test")));
+
+    List<CompUnit> units =
+        input.sources.entrySet().stream()
+            .map(e -> new SourceFile(e.getKey(), e.getValue()))
+            .map(Parser::parse)
+            .collect(toList());
+
+    Binder.BindingResult bound =
+        Binder.bind(
+            units,
+            ClassPathBinder.bindClasspath(ImmutableList.of()),
+            TestClassPaths.TURBINE_BOOTCLASSPATH,
+            Optional.empty());
+
+    Env<ClassSymbol, TypeBoundClass> env =
+        CompoundEnv.<ClassSymbol, TypeBoundClass>of(bound.classPathEnv())
+            .append(new SimpleEnv<>(bound.units()));
+    ModelFactory factory = new ModelFactory(env);
+    TurbineTypes turbineTypes = new TurbineTypes(factory);
+    TurbineElements turbineElements = new TurbineElements(factory, turbineTypes);
+    List<? extends Element> turbineMembers =
+        turbineElements.getAllMembers(factory.typeElement(new ClassSymbol("Test")));
+
+    assertThat(formatElements(turbineMembers))
+        .containsExactlyElementsIn(formatElements(javacMembers));
+  }
+
+  private static ImmutableList<String> formatElements(Collection<? extends Element> elements) {
+    return elements.stream()
+        .map(e -> String.format("%s %s.%s %s", e.getKind(), e.getEnclosingElement(), e, e.asType()))
+        .collect(toImmutableList());
+  }
+}

--- a/javatests/com/google/turbine/processing/TurbineNameTest.java
+++ b/javatests/com/google/turbine/processing/TurbineNameTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TurbineNameTest {
+
+  @Test
+  public void equals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new TurbineName("hello"), new TurbineName("hello"), new TurbineName("hello"))
+        .addEqualityGroup(new TurbineName("is"))
+        .addEqualityGroup(new TurbineName("there"))
+        .addEqualityGroup(new TurbineName("anybody"))
+        .addEqualityGroup(new TurbineName("in"))
+        .testEquals();
+  }
+
+  @Test
+  public void asd() {
+    assertThat(new TurbineName("hello").contentEquals("hello")).isTrue();
+    assertThat(new TurbineName("hello").contentEquals("goodbye")).isFalse();
+
+    assertThat(new TurbineName("hello").length()).isEqualTo(5);
+
+    assertThat(new TurbineName("hello").charAt(0)).isEqualTo('h');
+
+    assertThat(new TurbineName("hello").subSequence(1, 4).toString()).isEqualTo("ell");
+
+    assertThat(new TurbineName("hello").toString()).isEqualTo("hello");
+  }
+}

--- a/javatests/com/google/turbine/processing/TurbineTypeMirrorTest.java
+++ b/javatests/com/google/turbine/processing/TurbineTypeMirrorTest.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.testing.EqualsTester;
+import com.google.turbine.binder.sym.ClassSymbol;
+import com.google.turbine.binder.sym.PackageSymbol;
+import com.google.turbine.binder.sym.TyVarSymbol;
+import com.google.turbine.model.TurbineConstantTypeKind;
+import com.google.turbine.testing.TestClassPaths;
+import com.google.turbine.type.Type;
+import com.google.turbine.type.Type.PrimTy;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.IntersectionType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
+import javax.lang.model.type.WildcardType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TurbineTypeMirrorTest {
+
+  private final ModelFactory factory = new ModelFactory(TestClassPaths.TURBINE_BOOTCLASSPATH.env());
+
+  @Test
+  public void primitiveTypes() {
+    for (TypeKind kind : TypeKind.values()) {
+      if (!kind.isPrimitive()) {
+        continue;
+      }
+      TurbineConstantTypeKind turbineKind = TurbineConstantTypeKind.valueOf(kind.name());
+      TypeMirror type = factory.asTypeMirror(PrimTy.create(turbineKind, ImmutableList.of()));
+      assertThat(type.getKind()).isEqualTo(kind);
+    }
+  }
+
+  @Test
+  public void equals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            factory.asTypeMirror(
+                Type.ClassTy.create(
+                    ImmutableList.of(
+                        Type.ClassTy.SimpleClassTy.create(
+                            new ClassSymbol("java/util/Map"),
+                            ImmutableList.of(),
+                            ImmutableList.of()),
+                        Type.ClassTy.SimpleClassTy.create(
+                            new ClassSymbol("java/util/Map$Entry"),
+                            ImmutableList.of(Type.ClassTy.STRING, Type.ClassTy.STRING),
+                            ImmutableList.of())))))
+        .addEqualityGroup(
+            factory.asTypeMirror(
+                Type.ClassTy.create(
+                    ImmutableList.of(
+                        Type.ClassTy.SimpleClassTy.create(
+                            new ClassSymbol("java/util/Map$Entry"),
+                            ImmutableList.of(Type.ClassTy.STRING, Type.ClassTy.OBJECT),
+                            ImmutableList.of())))))
+        .addEqualityGroup(
+            factory.asTypeMirror(
+                Type.ClassTy.asNonParametricClassTy(new ClassSymbol("java/util/Map$Entry"))))
+        .addEqualityGroup(
+            factory.asTypeMirror(PrimTy.create(TurbineConstantTypeKind.LONG, ImmutableList.of())),
+            factory.asTypeMirror(PrimTy.create(TurbineConstantTypeKind.LONG, ImmutableList.of())))
+        .addEqualityGroup(
+            factory.asTypeMirror(PrimTy.create(TurbineConstantTypeKind.INT, ImmutableList.of())))
+        .addEqualityGroup(
+            factory.asTypeMirror(
+                Type.WildLowerBoundedTy.create(
+                    Type.ClassTy.asNonParametricClassTy(new ClassSymbol("java/lang/Integer")),
+                    ImmutableList.of())))
+        .addEqualityGroup(
+            factory.asTypeMirror(
+                Type.WildUpperBoundedTy.create(
+                    Type.ClassTy.asNonParametricClassTy(new ClassSymbol("java/lang/Integer")),
+                    ImmutableList.of())))
+        .addEqualityGroup(factory.asTypeMirror(Type.WildUnboundedTy.create(ImmutableList.of())))
+        .addEqualityGroup(
+            factory.asTypeMirror(
+                Type.ArrayTy.create(
+                    PrimTy.create(TurbineConstantTypeKind.LONG, ImmutableList.of()),
+                    ImmutableList.of())))
+        .addEqualityGroup(factory.packageType(new PackageSymbol("java/lang")))
+        .addEqualityGroup(
+            factory.asTypeMirror(
+                Type.TyVar.create(
+                    new TyVarSymbol(new ClassSymbol("java/util/List"), "V"), ImmutableList.of())))
+        .addEqualityGroup(
+            factory.asTypeMirror(
+                Type.IntersectionTy.create(
+                    ImmutableList.of(
+                        Type.ClassTy.asNonParametricClassTy(
+                            new ClassSymbol("java/io/Serializable")),
+                        Type.ClassTy.asNonParametricClassTy(
+                            new ClassSymbol("java/lang/Cloneable"))))))
+        .addEqualityGroup(factory.noType())
+        .testEquals();
+  }
+
+  @Test
+  public void roundTrip() {
+    DeclaredType te =
+        (DeclaredType)
+            factory.asTypeMirror(
+                Type.ClassTy.create(
+                    ImmutableList.of(
+                        Type.ClassTy.SimpleClassTy.create(
+                            new ClassSymbol("java/util/List"),
+                            ImmutableList.of(
+                                Type.ClassTy.asNonParametricClassTy(
+                                    new ClassSymbol("java/lang/String"))),
+                            ImmutableList.of()))));
+    assertThat(te.asElement().asType()).isNotEqualTo(te);
+    assertThat(te.asElement().asType())
+        .isEqualTo(
+            factory.asTypeMirror(
+                Type.ClassTy.create(
+                    ImmutableList.of(
+                        Type.ClassTy.SimpleClassTy.create(
+                            new ClassSymbol("java/util/List"),
+                            ImmutableList.of(
+                                Type.TyVar.create(
+                                    new TyVarSymbol(new ClassSymbol("java/util/List"), "E"),
+                                    ImmutableList.of())),
+                            ImmutableList.of())))));
+  }
+
+  @Test
+  public void wildTy() {
+    WildcardType lower =
+        (WildcardType)
+            factory.asTypeMirror(
+                Type.WildLowerBoundedTy.create(
+                    Type.ClassTy.asNonParametricClassTy(new ClassSymbol("java/lang/Integer")),
+                    ImmutableList.of()));
+    WildcardType upper =
+        (WildcardType)
+            factory.asTypeMirror(
+                Type.WildUpperBoundedTy.create(
+                    Type.ClassTy.asNonParametricClassTy(new ClassSymbol("java/lang/Long")),
+                    ImmutableList.of()));
+    WildcardType unbound =
+        (WildcardType) factory.asTypeMirror(Type.WildUnboundedTy.create(ImmutableList.of()));
+
+    assertThat(lower.getKind()).isEqualTo(TypeKind.WILDCARD);
+    assertThat(lower.getExtendsBound()).isNull();
+    assertThat(lower.getSuperBound().getKind()).isEqualTo(TypeKind.DECLARED);
+
+    assertThat(upper.getKind()).isEqualTo(TypeKind.WILDCARD);
+    assertThat(upper.getExtendsBound().getKind()).isEqualTo(TypeKind.DECLARED);
+    assertThat(upper.getSuperBound()).isNull();
+
+    assertThat(unbound.getKind()).isEqualTo(TypeKind.WILDCARD);
+    assertThat(unbound.getExtendsBound()).isNull();
+    assertThat(unbound.getSuperBound()).isNull();
+  }
+
+  @Test
+  public void intersection() {
+    IntersectionType t =
+        (IntersectionType)
+            factory.asTypeMirror(
+                Type.IntersectionTy.create(
+                    ImmutableList.of(
+                        Type.ClassTy.asNonParametricClassTy(
+                            new ClassSymbol("java/io/Serializable")),
+                        Type.ClassTy.asNonParametricClassTy(
+                            new ClassSymbol("java/lang/Cloneable")))));
+
+    assertThat(t.getKind()).isEqualTo(TypeKind.INTERSECTION);
+    assertThat(t.getBounds())
+        .containsExactlyElementsIn(
+            factory.asTypeMirrors(
+                ImmutableList.of(
+                    Type.ClassTy.asNonParametricClassTy(new ClassSymbol("java/io/Serializable")),
+                    Type.ClassTy.asNonParametricClassTy(new ClassSymbol("java/lang/Cloneable")))));
+  }
+
+  @Test
+  public void tyVar() {
+    TypeVariable t =
+        (TypeVariable)
+            Iterables.getOnlyElement(
+                    factory
+                        .typeElement(new ClassSymbol("java/util/Collections"))
+                        .getEnclosedElements()
+                        .stream()
+                        .filter(e -> e.getSimpleName().contentEquals("sort"))
+                        .filter(ExecutableElement.class::isInstance)
+                        .map(ExecutableElement.class::cast)
+                        .filter(e -> e.getParameters().size() == 1)
+                        .findFirst()
+                        .get()
+                        .getTypeParameters())
+                .asType();
+    assertThat(t.getKind()).isEqualTo(TypeKind.TYPEVAR);
+    assertThat(t.getLowerBound().getKind()).isEqualTo(TypeKind.NONE);
+    assertThat(t.getUpperBound().toString()).isEqualTo("java.lang.Comparable<? super T>");
+  }
+
+  @Test
+  public void arrayType() {
+    ArrayType t =
+        (ArrayType)
+            factory.asTypeMirror(
+                Type.ArrayTy.create(
+                    PrimTy.create(TurbineConstantTypeKind.LONG, ImmutableList.of()),
+                    ImmutableList.of()));
+    assertThat(t.getKind()).isEqualTo(TypeKind.ARRAY);
+    assertThat(t.getComponentType().getKind()).isEqualTo(TypeKind.LONG);
+  }
+
+  @Test
+  public void declared() {
+    DeclaredType a =
+        (DeclaredType)
+            factory.asTypeMirror(
+                Type.ClassTy.create(
+                    ImmutableList.of(
+                        Type.ClassTy.SimpleClassTy.create(
+                            new ClassSymbol("java/util/Map"),
+                            ImmutableList.of(),
+                            ImmutableList.of()),
+                        Type.ClassTy.SimpleClassTy.create(
+                            new ClassSymbol("java/util/Map$Entry"),
+                            ImmutableList.of(Type.ClassTy.STRING, Type.ClassTy.STRING),
+                            ImmutableList.of()))));
+    DeclaredType b =
+        (DeclaredType)
+            factory.asTypeMirror(
+                Type.ClassTy.asNonParametricClassTy(new ClassSymbol("java/util/Map$Entry")));
+
+    assertThat(a.getEnclosingType().toString()).isEqualTo("java.util.Map");
+    assertThat(b.getEnclosingType().toString()).isEqualTo("java.util.Map");
+  }
+}

--- a/javatests/com/google/turbine/processing/TurbineTypeMirrorTest.java
+++ b/javatests/com/google/turbine/processing/TurbineTypeMirrorTest.java
@@ -196,6 +196,7 @@ public class TurbineTypeMirrorTest {
         .containsExactlyElementsIn(
             factory.asTypeMirrors(
                 ImmutableList.of(
+                    Type.ClassTy.asNonParametricClassTy(new ClassSymbol("java/lang/Object")),
                     Type.ClassTy.asNonParametricClassTy(new ClassSymbol("java/io/Serializable")),
                     Type.ClassTy.asNonParametricClassTy(new ClassSymbol("java/lang/Cloneable")))));
   }
@@ -254,7 +255,7 @@ public class TurbineTypeMirrorTest {
             factory.asTypeMirror(
                 Type.ClassTy.asNonParametricClassTy(new ClassSymbol("java/util/Map$Entry")));
 
-    assertThat(a.getEnclosingType().toString()).isEqualTo("java.util.Map");
-    assertThat(b.getEnclosingType().toString()).isEqualTo("java.util.Map");
+    assertThat(a.getEnclosingType().getKind()).isEqualTo(TypeKind.NONE);
+    assertThat(b.getEnclosingType().getKind()).isEqualTo(TypeKind.NONE);
   }
 }

--- a/javatests/com/google/turbine/processing/TurbineTypeMirrorTest.java
+++ b/javatests/com/google/turbine/processing/TurbineTypeMirrorTest.java
@@ -16,6 +16,7 @@
 
 package com.google.turbine.processing;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
@@ -29,8 +30,10 @@ import com.google.turbine.testing.TestClassPaths;
 import com.google.turbine.type.Type;
 import com.google.turbine.type.Type.PrimTy;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ExecutableType;
 import javax.lang.model.type.IntersectionType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -257,5 +260,18 @@ public class TurbineTypeMirrorTest {
 
     assertThat(a.getEnclosingType().getKind()).isEqualTo(TypeKind.NONE);
     assertThat(b.getEnclosingType().getKind()).isEqualTo(TypeKind.NONE);
+  }
+
+  @Test
+  public void method() {
+    ExecutableType type =
+        (ExecutableType)
+            ((TypeElement) factory.typeElement(new ClassSymbol("java/util/Collections")))
+                .getEnclosedElements().stream()
+                    .filter(e -> e.getSimpleName().contentEquals("replaceAll"))
+                    .collect(onlyElement())
+                    .asType();
+    assertThat(type.getTypeVariables()).hasSize(1);
+    assertThat(type.toString()).isEqualTo("<T>(java.util.List<T>,T,T)boolean");
   }
 }

--- a/javatests/com/google/turbine/processing/TurbineTypesContainsTest.java
+++ b/javatests/com/google/turbine/processing/TurbineTypesContainsTest.java
@@ -40,10 +40,13 @@ public class TurbineTypesContainsTest extends AbstractTurbineTypesBiPredicateTes
 
   @Test
   public void contains() {
-
     // crashes javac
     assume().that(javacInput.lhs.getKind()).isNotEqualTo(TypeKind.NONE);
     assume().that(javacInput.rhs.getKind()).isNotEqualTo(TypeKind.NONE);
+
+    // crashes javac
+    assume().that(javacInput.lhs.getKind()).isNotEqualTo(TypeKind.EXECUTABLE);
+    assume().that(javacInput.rhs.getKind()).isNotEqualTo(TypeKind.EXECUTABLE);
 
     test("<=", Types::contains);
   }

--- a/javatests/com/google/turbine/processing/TurbineTypesContainsTest.java
+++ b/javatests/com/google/turbine/processing/TurbineTypesContainsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.truth.TruthJUnit.assume;
+
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.util.Types;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class TurbineTypesContainsTest extends AbstractTurbineTypesBiPredicateTest {
+
+  @Parameters(name = "{index}: {0}")
+  public static Iterable<Object[]> parameters() throws Exception {
+    return binaryParameters();
+  }
+
+  public TurbineTypesContainsTest(
+      String name, TypesBiFunctionInput javacInput, TypesBiFunctionInput turbineInput) {
+    super(name, javacInput, turbineInput);
+  }
+
+  @Test
+  public void contains() {
+
+    // crashes javac
+    assume().that(javacInput.lhs.getKind()).isNotEqualTo(TypeKind.NONE);
+    assume().that(javacInput.rhs.getKind()).isNotEqualTo(TypeKind.NONE);
+
+    test("<=", Types::contains);
+  }
+}

--- a/javatests/com/google/turbine/processing/TurbineTypesIsAssignableTest.java
+++ b/javatests/com/google/turbine/processing/TurbineTypesIsAssignableTest.java
@@ -48,6 +48,10 @@ public class TurbineTypesIsAssignableTest extends AbstractTurbineTypesBiPredicat
     assume().that(javacInput.lhs.getKind()).isNotEqualTo(TypeKind.NONE);
     assume().that(javacInput.rhs.getKind()).isNotEqualTo(TypeKind.NONE);
 
+    // crashes javac
+    assume().that(javacInput.lhs.getKind()).isNotEqualTo(TypeKind.EXECUTABLE);
+    assume().that(javacInput.rhs.getKind()).isNotEqualTo(TypeKind.EXECUTABLE);
+
     test("isAssignable", Types::isAssignable);
   }
 }

--- a/javatests/com/google/turbine/processing/TurbineTypesIsAssignableTest.java
+++ b/javatests/com/google/turbine/processing/TurbineTypesIsAssignableTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.truth.TruthJUnit.assume;
+
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.util.Types;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class TurbineTypesIsAssignableTest extends AbstractTurbineTypesBiPredicateTest {
+
+  @Parameters(name = "{index}: {0}")
+  public static Iterable<Object[]> parameters() throws Exception {
+    return binaryParameters();
+  }
+
+  public TurbineTypesIsAssignableTest(
+      String testDescription, TypesBiFunctionInput javacInput, TypesBiFunctionInput turbineInput) {
+    super(testDescription, javacInput, turbineInput);
+  }
+
+  @Test
+  public void isAssignable() {
+    // see JDK-8039198
+    assume().that(javacInput.lhs.getKind()).isNotEqualTo(TypeKind.WILDCARD);
+    assume().that(javacInput.rhs.getKind()).isNotEqualTo(TypeKind.WILDCARD);
+
+    // crashes javac
+    assume().that(javacInput.lhs.getKind()).isNotEqualTo(TypeKind.NONE);
+    assume().that(javacInput.rhs.getKind()).isNotEqualTo(TypeKind.NONE);
+
+    test("isAssignable", Types::isAssignable);
+  }
+}

--- a/javatests/com/google/turbine/processing/TurbineTypesIsSameTypeTest.java
+++ b/javatests/com/google/turbine/processing/TurbineTypesIsSameTypeTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import javax.lang.model.util.Types;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class TurbineTypesIsSameTypeTest extends AbstractTurbineTypesBiPredicateTest {
+
+  @Parameters(name = "{index}: {0}")
+  public static Iterable<Object[]> parameters() throws Exception {
+    return binaryParameters();
+  }
+
+  public TurbineTypesIsSameTypeTest(
+      String testDescription, TypesBiFunctionInput javacInput, TypesBiFunctionInput turbineInput) {
+    super(testDescription, javacInput, turbineInput);
+  }
+
+  @Test
+  public void isSameType() {
+    test("isSameType", Types::isSameType);
+  }
+}

--- a/javatests/com/google/turbine/processing/TurbineTypesIsSubsignatureTest.java
+++ b/javatests/com/google/turbine/processing/TurbineTypesIsSubsignatureTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.truth.TruthJUnit.assume;
+
+import javax.lang.model.type.ExecutableType;
+import javax.lang.model.type.TypeKind;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class TurbineTypesIsSubsignatureTest extends AbstractTurbineTypesBiPredicateTest {
+
+  @Parameters(name = "{index}: {0}")
+  public static Iterable<Object[]> parameters() throws Exception {
+    return binaryParameters();
+  }
+
+  public TurbineTypesIsSubsignatureTest(
+      String testDescription, TypesBiFunctionInput javacInput, TypesBiFunctionInput turbineInput) {
+    super(testDescription, javacInput, turbineInput);
+  }
+
+  @Test
+  public void isSubsignature() {
+    assume().that(javacInput.lhs.getKind()).isEqualTo(TypeKind.EXECUTABLE);
+    assume().that(javacInput.rhs.getKind()).isEqualTo(TypeKind.EXECUTABLE);
+
+    test(
+        "isSubsignature",
+        (types, x, y) -> types.isSubsignature((ExecutableType) x, (ExecutableType) y));
+  }
+}

--- a/javatests/com/google/turbine/processing/TurbineTypesIsSubtypeTest.java
+++ b/javatests/com/google/turbine/processing/TurbineTypesIsSubtypeTest.java
@@ -48,6 +48,10 @@ public class TurbineTypesIsSubtypeTest extends AbstractTurbineTypesBiPredicateTe
     assume().that(javacInput.lhs.getKind()).isNotEqualTo(TypeKind.NONE);
     assume().that(javacInput.rhs.getKind()).isNotEqualTo(TypeKind.NONE);
 
+    // crashes javac
+    assume().that(javacInput.lhs.getKind()).isNotEqualTo(TypeKind.EXECUTABLE);
+    assume().that(javacInput.rhs.getKind()).isNotEqualTo(TypeKind.EXECUTABLE);
+
     test("<:", Types::isSubtype);
   }
 }

--- a/javatests/com/google/turbine/processing/TurbineTypesIsSubtypeTest.java
+++ b/javatests/com/google/turbine/processing/TurbineTypesIsSubtypeTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.truth.TruthJUnit.assume;
+
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.util.Types;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class TurbineTypesIsSubtypeTest extends AbstractTurbineTypesBiPredicateTest {
+
+  @Parameters(name = "{index}: {0}")
+  public static Iterable<Object[]> parameters() throws Exception {
+    return binaryParameters();
+  }
+
+  public TurbineTypesIsSubtypeTest(
+      String testDescription, TypesBiFunctionInput javacInput, TypesBiFunctionInput turbineInput) {
+    super(testDescription, javacInput, turbineInput);
+  }
+
+  @Test
+  public void isSubtype() {
+    // see JDK-8039198
+    assume().that(javacInput.lhs.getKind()).isNotEqualTo(TypeKind.WILDCARD);
+    assume().that(javacInput.rhs.getKind()).isNotEqualTo(TypeKind.WILDCARD);
+
+    // crashes javac
+    assume().that(javacInput.lhs.getKind()).isNotEqualTo(TypeKind.NONE);
+    assume().that(javacInput.rhs.getKind()).isNotEqualTo(TypeKind.NONE);
+
+    test("<:", Types::isSubtype);
+  }
+}

--- a/javatests/com/google/turbine/processing/TurbineTypesUnaryTest.java
+++ b/javatests/com/google/turbine/processing/TurbineTypesUnaryTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static com.google.common.truth.TruthJUnit.assume;
+import static org.junit.Assert.fail;
+
+import javax.lang.model.type.PrimitiveType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Types;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class TurbineTypesUnaryTest extends AbstractTurbineTypesTest {
+
+  @Parameters(name = "{index}: {0}")
+  public static Iterable<Object[]> parameters() throws Exception {
+    return unaryParameters();
+  }
+
+  final String testDescription;
+  final Types javacTypes;
+  final TypeMirror javacA;
+  final Types turbineTypes;
+  final TypeMirror turbineA;
+
+  public TurbineTypesUnaryTest(
+      String testDescription,
+      Types javacTypes,
+      TypeMirror javacA,
+      Types turbineTypes,
+      TypeMirror turbineA) {
+    this.testDescription = testDescription;
+    this.javacTypes = javacTypes;
+    this.javacA = javacA;
+    this.turbineTypes = turbineTypes;
+    this.turbineA = turbineA;
+  }
+
+  @Test
+  public void unboxedType() {
+    IllegalArgumentException thrown = null;
+    String expectedType = null;
+    try {
+      expectedType = javacTypes.unboxedType(javacA).toString();
+    } catch (IllegalArgumentException e) {
+      thrown = e;
+    }
+    if (thrown != null) {
+      try {
+        turbineTypes.unboxedType(turbineA).toString();
+        fail(String.format("expected unboxedType(`%s`) to throw", turbineA));
+      } catch (IllegalArgumentException expected) {
+        // expected
+      }
+    } else {
+      String actual = turbineTypes.unboxedType(turbineA).toString();
+      assertWithMessage("unboxedClass(`%s`) = unboxedClass(`%s`)", javacA, turbineA)
+          .that(actual)
+          .isEqualTo(expectedType);
+    }
+  }
+
+  @Test
+  public void boxedClass() {
+    assume().that(javacA).isInstanceOf(PrimitiveType.class);
+    assume().that(turbineA).isInstanceOf(PrimitiveType.class);
+
+    String expected = javacTypes.boxedClass((PrimitiveType) javacA).toString();
+    String actual = turbineTypes.boxedClass((PrimitiveType) turbineA).toString();
+    assertWithMessage("boxedClass(`%s`) = boxedClass(`%s`)", javacA, turbineA)
+        .that(actual)
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void erasure() {
+    String expected = javacTypes.erasure(javacA).toString();
+    String actual = turbineTypes.erasure(turbineA).toString();
+    assertWithMessage("erasure(`%s`) = erasure(`%s`)", javacA, turbineA)
+        .that(actual)
+        .isEqualTo(expected);
+  }
+}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Initial support for preserving javadoc comments in the parser

Which will eventually be used to support e.g.:
https://docs.oracle.com/en/java/javase/11/docs/api/java.compiler/javax/lang/model/util/Elements.html#getDocComment(javax.lang.model.element.Element)

dcafb90aec6c65c3b06321f21ba8d035aa33f8c1

-------

<p> Initial implementation of Element and TypeMirror model classes

backed by turbine's Symbol and Type, respectively.

0fea76a9a6742690ec88b8045aa1399b19747d20

-------

<p> Remove some unnecessary casts

301ccc25564a5513f5a37a83b7d08054ea59f3f3

-------

<p> Initial implementation of javax.lang.model.util.Types

https://docs.oracle.com/en/java/javase/11/docs/api/java.compiler/javax/lang/model/util/Types.html

8d5acb84d8c94c5274e32fdefcddc233371e687d

-------

<p> Implement ExecutableType and corresponding support in Types

af102ea52f00f83c1c32435d8295cb15f9ef9321

-------

<p> Add a TurbineElement.sym getter, and use consistent naming

8a80ee282ba8d5291631133ed7615ae7cd2ae5a6

-------

<p> Use a Multimap with linked hash keys, to preserve ordering

04c9ece240e602d6fa063f9c36bcaadaa056b0ab

-------

<p> Ensure Const.toString representations are valid Java code

Escape strings, and add explicit casts to deficient numeric types.

db72495b9f7b5a8f1ca6f896aee41d394cdafca5

-------

<p> Fix a typo

ad99b7e11516750d2f6f17b4d7925d27aa428d88

-------

<p> Use the regular @Nullable annotation instead of @NullableType

the latter is only needed in compilations that mix declaration and type
annotation nullness annotations, this was a typo.

7be1f2412871d06df782c6a355aebf7452992b3d

-------

<p> Initial implementation of TurbineElements.getAllMembers

see https://docs.oracle.com/en/java/javase/11/docs/api/java.compiler/javax/lang/model/util/Elements.html#getAllMembers(javax.lang.model.element.TypeElement)

47d9326a8d019c462cd0020d36f44b4f442d18ec