### PR TITLE
Moe Sync

### DIFF
--- a/java/com/google/turbine/binder/ConstEvaluator.java
+++ b/java/com/google/turbine/binder/ConstEvaluator.java
@@ -383,7 +383,7 @@ public strictfp class ConstEvaluator {
     }
   }
 
-  private Value unaryNegate(Value expr) {
+  private static Value unaryNegate(Value expr) {
     switch (expr.constantTypeKind()) {
       case BOOLEAN:
         return new Const.BooleanValue(!expr.asBoolean().value());
@@ -392,7 +392,7 @@ public strictfp class ConstEvaluator {
     }
   }
 
-  private Value bitwiseComp(Value expr) {
+  private static Value bitwiseComp(Value expr) {
     expr = promoteUnary(expr);
     switch (expr.constantTypeKind()) {
       case INT:
@@ -404,7 +404,7 @@ public strictfp class ConstEvaluator {
     }
   }
 
-  private Value unaryPlus(Value expr) {
+  private static Value unaryPlus(Value expr) {
     expr = promoteUnary(expr);
     switch (expr.constantTypeKind()) {
       case INT:
@@ -420,7 +420,7 @@ public strictfp class ConstEvaluator {
     }
   }
 
-  private Value unaryMinus(Value expr) {
+  private static Value unaryMinus(Value expr) {
     expr = promoteUnary(expr);
     switch (expr.constantTypeKind()) {
       case INT:

--- a/java/com/google/turbine/binder/ModuleBinder.java
+++ b/java/com/google/turbine/binder/ModuleBinder.java
@@ -179,11 +179,11 @@ public class ModuleBinder {
     return new RequireInfo(moduleName, flags, requires != null ? requires.version() : null);
   }
 
-  private ExportInfo bindExports(ModExports directive) {
+  private static ExportInfo bindExports(ModExports directive) {
     return new ExportInfo(directive.packageName(), directive.moduleNames());
   }
 
-  private OpenInfo bindOpens(ModOpens directive) {
+  private static OpenInfo bindOpens(ModOpens directive) {
     return new OpenInfo(directive.packageName(), directive.moduleNames());
   }
 

--- a/java/com/google/turbine/binder/bound/TypeBoundClass.java
+++ b/java/com/google/turbine/binder/bound/TypeBoundClass.java
@@ -246,7 +246,6 @@ public interface TypeBoundClass extends HeaderBoundClass {
 
     public MethodTy asType() {
       return MethodTy.create(
-          name(),
           tyParams.keySet(),
           returnType,
           receiver != null ? receiver.type() : null,

--- a/java/com/google/turbine/binder/bytecode/BytecodeBoundClass.java
+++ b/java/com/google/turbine/binder/bytecode/BytecodeBoundClass.java
@@ -500,7 +500,7 @@ public class BytecodeBoundClass implements BoundClass, HeaderBoundClass, TypeBou
             }
           });
 
-  private RetentionPolicy bindRetention(AnnotationInfo annotation) {
+  private static RetentionPolicy bindRetention(AnnotationInfo annotation) {
     ElementValue val = annotation.elementValuePairs().get("value");
     if (val.kind() != Kind.ENUM) {
       return null;

--- a/java/com/google/turbine/diag/TurbineError.java
+++ b/java/com/google/turbine/diag/TurbineError.java
@@ -31,6 +31,7 @@ public class TurbineError extends Error {
     UNTERMINATED_STRING("unterminated string literal"),
     UNTERMINATED_CHARACTER_LITERAL("unterminated char literal"),
     UNTERMINATED_EXPRESSION("unterminated expression, expected ';' not found"),
+    INVALID_UNICODE("illegal unicode escape"),
     EMPTY_CHARACTER_LITERAL("empty char literal"),
     EXPECTED_TOKEN("expected token %s"),
     INVALID_LITERAL("invalid literal: %s"),

--- a/java/com/google/turbine/parse/Parser.java
+++ b/java/com/google/turbine/parse/Parser.java
@@ -348,7 +348,7 @@ public class Parser {
     return new ModDecl(pos, annos, open, moduleName, directives.build());
   }
 
-  private String flatname(char join, ImmutableList<Ident> idents) {
+  private static String flatname(char join, ImmutableList<Ident> idents) {
     StringBuilder sb = new StringBuilder();
     boolean first = true;
     for (Ident ident : idents) {
@@ -938,7 +938,7 @@ public class Parser {
     return ty;
   }
 
-  private Type extraDims(Type type, Deque<ImmutableList<Anno>> extra) {
+  private static Type extraDims(Type type, Deque<ImmutableList<Anno>> extra) {
     if (extra.isEmpty()) {
       return type;
     }

--- a/java/com/google/turbine/parse/StreamLexer.java
+++ b/java/com/google/turbine/parse/StreamLexer.java
@@ -1024,7 +1024,7 @@ public class StreamLexer implements Lexer {
     return makeIdent(stringValue());
   }
 
-  private Token makeIdent(String s) {
+  private static Token makeIdent(String s) {
     switch (s) {
       case "abstract":
         return Token.ABSTRACT;

--- a/java/com/google/turbine/processing/TurbineElements.java
+++ b/java/com/google/turbine/processing/TurbineElements.java
@@ -259,6 +259,9 @@ public class TurbineElements implements Elements {
   @Override
   public boolean overrides(
       ExecutableElement overrider, ExecutableElement overridden, TypeElement type) {
+    if (!overrider.getSimpleName().contentEquals(overridden.getSimpleName())) {
+      return false;
+    }
     TypeMirror a = overrider.asType();
     TypeMirror b = types.asMemberOf((DeclaredType) type.asType(), overridden);
     if (b == null) {

--- a/java/com/google/turbine/processing/TurbineTypes.java
+++ b/java/com/google/turbine/processing/TurbineTypes.java
@@ -63,7 +63,7 @@ import javax.lang.model.type.WildcardType;
 import javax.lang.model.util.Types;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-/** An implementation of {@link Types} backed by turbine's of {@link TypeMirror}. */
+/** An implementation of {@link Types} backed by turbine's {@link TypeMirror}. */
 public class TurbineTypes implements Types {
 
   private final ModelFactory factory;

--- a/java/com/google/turbine/processing/TurbineTypes.java
+++ b/java/com/google/turbine/processing/TurbineTypes.java
@@ -771,15 +771,11 @@ public class TurbineTypes implements Types {
     // adapt the formal parameter types of 'b' to the type parameters of 'a'
     Iterator<Type> bx = substAll(b.parameters(), mapping).iterator();
     while (ax.hasNext()) {
-      if (!eqOrErasedEq(ax.next(), bx.next())) {
+      if (!isSameType(ax.next(), bx.next())) {
         return false;
       }
     }
     return true;
-  }
-
-  boolean eqOrErasedEq(Type a, Type b) {
-    return isSameType(a, b) || isSameType(erasure(a), erasure(b));
   }
 
   @Override

--- a/java/com/google/turbine/processing/TurbineTypes.java
+++ b/java/com/google/turbine/processing/TurbineTypes.java
@@ -536,7 +536,6 @@ public class TurbineTypes implements Types {
 
   static MethodTy substMethod(MethodTy method, Map<TyVarSymbol, Type> mapping) {
     return MethodTy.create(
-        method.name(),
         method.tyParams(),
         subst(method.returnType(), mapping),
         method.receiverType() != null ? subst(method.receiverType(), mapping) : null,
@@ -755,8 +754,6 @@ public class TurbineTypes implements Types {
   }
 
   private boolean isSameSignature(MethodTy a, MethodTy b) {
-    // JLS 8.4.2 says "two methods have the same signature if they have the same name...", but
-    // javac's implementation of isSubsignature ignores names, so we do too for bug compatibility.
     if (a.parameters().size() != b.parameters().size()) {
       return false;
     }

--- a/java/com/google/turbine/type/Type.java
+++ b/java/com/google/turbine/type/Type.java
@@ -476,8 +476,6 @@ public interface Type {
   @AutoValue
   abstract class MethodTy implements Type {
 
-    public abstract String name();
-
     public abstract ImmutableSet<TyVarSymbol> tyParams();
 
     public abstract Type returnType();
@@ -491,14 +489,12 @@ public interface Type {
     public abstract ImmutableList<Type> thrown();
 
     public static MethodTy create(
-        String name,
         ImmutableSet<TyVarSymbol> tyParams,
         Type returnType,
         Type receiverType,
         ImmutableList<Type> parameters,
         ImmutableList<Type> thrown) {
-      return new AutoValue_Type_MethodTy(
-          name, tyParams, returnType, receiverType, parameters, thrown);
+      return new AutoValue_Type_MethodTy(tyParams, returnType, receiverType, parameters, thrown);
     }
 
     @Override

--- a/java/com/google/turbine/types/Canonicalize.java
+++ b/java/com/google/turbine/types/Canonicalize.java
@@ -277,7 +277,7 @@ public class Canonicalize {
   }
 
   /** Instantiates a type argument using the given mapping. */
-  private Type instantiate(Map<TyVarSymbol, Type> mapping, Type type) {
+  private static Type instantiate(Map<TyVarSymbol, Type> mapping, Type type) {
     if (type == null) {
       return null;
     }
@@ -304,7 +304,7 @@ public class Canonicalize {
     }
   }
 
-  private Type instantiateWildTy(Map<TyVarSymbol, Type> mapping, WildTy type) {
+  private static Type instantiateWildTy(Map<TyVarSymbol, Type> mapping, WildTy type) {
     switch (type.boundKind()) {
       case NONE:
         return type;
@@ -318,7 +318,7 @@ public class Canonicalize {
     throw new AssertionError(type.boundKind());
   }
 
-  private Type instantiateClassTy(Map<TyVarSymbol, Type> mapping, ClassTy type) {
+  private static Type instantiateClassTy(Map<TyVarSymbol, Type> mapping, ClassTy type) {
     ImmutableList.Builder<SimpleClassTy> simples = ImmutableList.builder();
     for (SimpleClassTy simple : type.classes()) {
       ImmutableList.Builder<Type> args = ImmutableList.builder();
@@ -335,7 +335,7 @@ public class Canonicalize {
    * reference, or else {@code null}.
    */
   @Nullable
-  private TyVarSymbol tyVarSym(Type type) {
+  private static TyVarSymbol tyVarSym(Type type) {
     if (type.tyKind() == TyKind.TY_VAR) {
       return ((TyVar) type).sym();
     }

--- a/java/com/google/turbine/types/Erasure.java
+++ b/java/com/google/turbine/types/Erasure.java
@@ -106,7 +106,6 @@ public class Erasure {
 
   private static Type erasureMethodTy(MethodTy ty, Function<TyVarSymbol, TyVarInfo> tenv) {
     return MethodTy.create(
-        ty.name(),
         /* tyParams= */ ImmutableSet.of(),
         erase(ty.returnType(), tenv),
         ty.receiverType() != null ? erase(ty.receiverType(), tenv) : null,

--- a/javatests/com/google/turbine/processing/AbstractTurbineTypesTest.java
+++ b/javatests/com/google/turbine/processing/AbstractTurbineTypesTest.java
@@ -319,11 +319,16 @@ class AbstractTurbineTypesTest {
                 "  class K {",
                 "    void f(K this, int x) {}",
                 "    void g(K this) {}",
+                "    <T extends Enum<T> & Serializable> void h(T t) {}",
                 "  }",
                 "  class L {",
                 "    void f(int x) {}",
                 "    void g() {}",
+                "    <E extends Enum<E> & Serializable> void h(E t) {}",
                 "  }",
+                "}",
+                "class M<T extends Enum<T> & Serializable> {",
+                "  void h(T t) {}",
                 "}"));
 
     Context context = new Context();


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix MethodCanBeStatic findings

a630f4c93e9ffcce798849d96625b6f207a33157

-------

<p> Fix a viral typo

08fc54bc9f1b406d9a045e31d2ab5cf9f49912ff

-------

<p> Fix a bug in signature comparison

Two methods signatures can be equivalent (or subsignatures) if they
have different type parameters with the same bounds. To account for this,
we adapt one of the method signatures to substitute all occurrences of
its type parameters with the corresponding type variable from the other
signature.

i.e., given `<X extends Enum<X>> void f(X x)` and
`<Y extends Enum<Y>> void f(Y y)` we first substitute X->Y.

ae8edf6e17705898e120018f619ae41212ab814b

-------

<p> Remove eqOrErased

this was made obsolete by the handling of erasure in
isSubsignature.

47f2a439871d548498a09f53dad9a5c0e0b1ee33

-------

<p> Improve unicode escape processing diagnostics

b074c3ce7e2f6691ba85f6026d62834b3cfaf3fc

-------

<p> Remove name from MethodTy

The name isn't part of the signature type, and methods that consider name (like
overrides) should access it separately.

8760730161065f2104eca60f24701de064de8ff0