### PR TITLE
Moe Sync

### DIFF
--- a/java/com/google/turbine/binder/ConstBinder.java
+++ b/java/com/google/turbine/binder/ConstBinder.java
@@ -33,6 +33,7 @@ import com.google.turbine.binder.env.Env;
 import com.google.turbine.binder.sym.ClassSymbol;
 import com.google.turbine.binder.sym.FieldSymbol;
 import com.google.turbine.binder.sym.TyVarSymbol;
+import com.google.turbine.diag.TurbineLog.TurbineLogWithSource;
 import com.google.turbine.model.Const;
 import com.google.turbine.model.Const.ArrayInitValue;
 import com.google.turbine.model.Const.Kind;
@@ -63,19 +64,29 @@ public class ConstBinder {
   private final SourceTypeBoundClass base;
   private final CompoundEnv<ClassSymbol, TypeBoundClass> env;
   private final ConstEvaluator constEvaluator;
+  private final TurbineLogWithSource log;
 
   public ConstBinder(
       Env<FieldSymbol, Value> constantEnv,
       ClassSymbol origin,
       CompoundEnv<ClassSymbol, TypeBoundClass> env,
-      SourceTypeBoundClass base) {
+      SourceTypeBoundClass base,
+      TurbineLogWithSource log) {
     this.constantEnv = constantEnv;
     this.origin = origin;
     this.base = base;
     this.env = env;
+    this.log = log;
     this.constEvaluator =
         new ConstEvaluator(
-            origin, origin, base.memberImports(), base.source(), base.scope(), constantEnv, env);
+            origin,
+            origin,
+            base.memberImports(),
+            base.source(),
+            base.scope(),
+            constantEnv,
+            env,
+            log);
   }
 
   public SourceTypeBoundClass bind() {
@@ -87,7 +98,8 @@ public class ConstBinder {
                 base.source(),
                 base.enclosingScope(),
                 constantEnv,
-                env)
+                env,
+                log)
             .evaluateAnnotations(base.annotations());
     ImmutableList<TypeBoundClass.FieldInfo> fields = fields(base.fields());
     ImmutableList<MethodInfo> methods = bindMethods(base.methods());

--- a/java/com/google/turbine/binder/ModuleBinder.java
+++ b/java/com/google/turbine/binder/ModuleBinder.java
@@ -40,6 +40,7 @@ import com.google.turbine.binder.sym.ClassSymbol;
 import com.google.turbine.binder.sym.ModuleSymbol;
 import com.google.turbine.diag.TurbineError;
 import com.google.turbine.diag.TurbineError.ErrorKind;
+import com.google.turbine.diag.TurbineLog.TurbineLogWithSource;
 import com.google.turbine.model.TurbineFlag;
 import com.google.turbine.tree.Tree;
 import com.google.turbine.tree.Tree.Ident;
@@ -60,8 +61,9 @@ public class ModuleBinder {
       PackageSourceBoundModule module,
       CompoundEnv<ClassSymbol, TypeBoundClass> env,
       Env<ModuleSymbol, ModuleInfo> moduleEnv,
-      Optional<String> moduleVersion) {
-    return new ModuleBinder(module, env, moduleEnv, moduleVersion).bind();
+      Optional<String> moduleVersion,
+      TurbineLogWithSource log) {
+    return new ModuleBinder(module, env, moduleEnv, moduleVersion, log).bind();
   }
 
   private final PackageSourceBoundModule module;
@@ -69,16 +71,19 @@ public class ModuleBinder {
   private final Env<ModuleSymbol, ModuleInfo> moduleEnv;
   private final Optional<String> moduleVersion;
   private final CompoundScope scope;
+  private final TurbineLogWithSource log;
 
   public ModuleBinder(
       PackageSourceBoundModule module,
       CompoundEnv<ClassSymbol, TypeBoundClass> env,
       Env<ModuleSymbol, ModuleInfo> moduleEnv,
-      Optional<String> moduleVersion) {
+      Optional<String> moduleVersion,
+      TurbineLogWithSource log) {
     this.module = module;
     this.env = env;
     this.moduleEnv = moduleEnv;
     this.moduleVersion = moduleVersion;
+    this.log = log;
     this.scope = module.scope().toScope(Resolve.resolveFunction(env, /* origin= */ null));
   }
 
@@ -92,7 +97,8 @@ public class ModuleBinder {
             module.source(),
             scope,
             /* values= */ new SimpleEnv<>(ImmutableMap.of()),
-            env);
+            env,
+            log);
     ImmutableList.Builder<AnnoInfo> annoInfos = ImmutableList.builder();
     for (Tree.Anno annoTree : module.module().annos()) {
       ClassSymbol sym = resolve(annoTree.position(), annoTree.name());

--- a/java/com/google/turbine/binder/bytecode/BytecodeBoundClass.java
+++ b/java/com/google/turbine/binder/bytecode/BytecodeBoundClass.java
@@ -443,8 +443,14 @@ public class BytecodeBoundClass implements BoundClass, HeaderBoundClass, TypeBou
     }
 
     ImmutableList.Builder<Type> exceptions = ImmutableList.builder();
-    for (TySig e : sig.exceptions()) {
-      exceptions.add(BytecodeBinder.bindTy(e, scope));
+    if (!sig.exceptions().isEmpty()) {
+      for (TySig e : sig.exceptions()) {
+        exceptions.add(BytecodeBinder.bindTy(e, scope));
+      }
+    } else {
+      for (String e : m.exceptions()) {
+        exceptions.add(ClassTy.asNonParametricClassTy(new ClassSymbol(e)));
+      }
     }
 
     Const defaultValue =

--- a/java/com/google/turbine/binder/sym/ClassSymbol.java
+++ b/java/com/google/turbine/binder/sym/ClassSymbol.java
@@ -33,6 +33,7 @@ public class ClassSymbol implements Symbol {
   public static final ClassSymbol STRING = new ClassSymbol("java/lang/String");
   public static final ClassSymbol ENUM = new ClassSymbol("java/lang/Enum");
   public static final ClassSymbol ANNOTATION = new ClassSymbol("java/lang/annotation/Annotation");
+  public static final ClassSymbol INHERITED = new ClassSymbol("java/lang/annotation/Inherited");
   public static final ClassSymbol ERROR = new ClassSymbol("<error>");
 
   public static final ClassSymbol CHARACTER = new ClassSymbol("java/lang/Character");

--- a/java/com/google/turbine/model/Const.java
+++ b/java/com/google/turbine/model/Const.java
@@ -415,6 +415,9 @@ public abstract class Const {
 
     @Override
     public String toString() {
+      if (Float.isNaN(value)) {
+        return "0.0f/0.0f";
+      }
       return value + "f";
     }
 
@@ -498,6 +501,15 @@ public abstract class Const {
 
     @Override
     public String toString() {
+      if (Double.isNaN(value)) {
+        return "0.0/0.0";
+      }
+      if (value == Double.POSITIVE_INFINITY) {
+        return "1.0/0.0";
+      }
+      if (value == Double.NEGATIVE_INFINITY) {
+        return "-1.0/0.0";
+      }
       return String.valueOf(value);
     }
 

--- a/java/com/google/turbine/model/Const.java
+++ b/java/com/google/turbine/model/Const.java
@@ -641,7 +641,7 @@ public abstract class Const {
 
     @Override
     public String toString() {
-      return String.format("(short)%d", value);
+      return String.valueOf(value);
     }
 
     @Override

--- a/java/com/google/turbine/model/Const.java
+++ b/java/com/google/turbine/model/Const.java
@@ -19,6 +19,8 @@ package com.google.turbine.model;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.escape.SourceCodeEscapers;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.AnnotationValueVisitor;
 
 /**
  * Compile-time constant expressions, including literals of primitive or String type, class
@@ -55,7 +57,7 @@ public abstract class Const {
   }
 
   /** Subtypes of {@link Const} for primitive and String literals. */
-  public abstract static class Value extends Const {
+  public abstract static class Value extends Const implements AnnotationValue {
     public abstract TurbineConstantTypeKind constantTypeKind();
 
     @Override
@@ -114,11 +116,21 @@ public abstract class Const {
     }
 
     @Override
+    public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+      return v.visitBoolean(value, p);
+    }
+
+    @Override
     public TurbineConstantTypeKind constantTypeKind() {
       return TurbineConstantTypeKind.BOOLEAN;
     }
 
     public boolean value() {
+      return value;
+    }
+
+    @Override
+    public Object getValue() {
       return value;
     }
 
@@ -158,11 +170,21 @@ public abstract class Const {
     }
 
     @Override
+    public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+      return v.visitInt(value, p);
+    }
+
+    @Override
     public TurbineConstantTypeKind constantTypeKind() {
       return TurbineConstantTypeKind.INT;
     }
 
     public int value() {
+      return value;
+    }
+
+    @Override
+    public Object getValue() {
       return value;
     }
 
@@ -231,11 +253,21 @@ public abstract class Const {
     }
 
     @Override
+    public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+      return v.visitLong(value, p);
+    }
+
+    @Override
     public TurbineConstantTypeKind constantTypeKind() {
       return TurbineConstantTypeKind.LONG;
     }
 
     public long value() {
+      return value;
+    }
+
+    @Override
+    public Object getValue() {
       return value;
     }
 
@@ -304,11 +336,21 @@ public abstract class Const {
     }
 
     @Override
+    public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+      return v.visitChar(value, p);
+    }
+
+    @Override
     public TurbineConstantTypeKind constantTypeKind() {
       return TurbineConstantTypeKind.CHAR;
     }
 
     public char value() {
+      return value;
+    }
+
+    @Override
+    public Object getValue() {
       return value;
     }
 
@@ -377,11 +419,21 @@ public abstract class Const {
     }
 
     @Override
+    public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+      return v.visitFloat(value, p);
+    }
+
+    @Override
     public TurbineConstantTypeKind constantTypeKind() {
       return TurbineConstantTypeKind.FLOAT;
     }
 
     public float value() {
+      return value;
+    }
+
+    @Override
+    public Object getValue() {
       return value;
     }
 
@@ -450,11 +502,21 @@ public abstract class Const {
     }
 
     @Override
+    public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+      return v.visitDouble(value, p);
+    }
+
+    @Override
     public TurbineConstantTypeKind constantTypeKind() {
       return TurbineConstantTypeKind.DOUBLE;
     }
 
     public double value() {
+      return value;
+    }
+
+    @Override
+    public Object getValue() {
       return value;
     }
 
@@ -523,11 +585,21 @@ public abstract class Const {
     }
 
     @Override
+    public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+      return v.visitString(value, p);
+    }
+
+    @Override
     public TurbineConstantTypeKind constantTypeKind() {
       return TurbineConstantTypeKind.STRING;
     }
 
     public String value() {
+      return value;
+    }
+
+    @Override
+    public Object getValue() {
       return value;
     }
 
@@ -561,11 +633,21 @@ public abstract class Const {
     }
 
     @Override
+    public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+      return v.visitShort(value, p);
+    }
+
+    @Override
     public TurbineConstantTypeKind constantTypeKind() {
       return TurbineConstantTypeKind.SHORT;
     }
 
     public short value() {
+      return value;
+    }
+
+    @Override
+    public Object getValue() {
       return value;
     }
 
@@ -639,6 +721,11 @@ public abstract class Const {
     }
 
     @Override
+    public Object getValue() {
+      return value;
+    }
+
+    @Override
     public IntValue asInteger() {
       return new IntValue((int) value);
     }
@@ -691,6 +778,11 @@ public abstract class Const {
     @Override
     public String toString() {
       return String.format("(byte)0x%02x", value);
+    }
+
+    @Override
+    public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+      return v.visitByte(value, p);
     }
   }
 

--- a/java/com/google/turbine/parse/IteratorLexer.java
+++ b/java/com/google/turbine/parse/IteratorLexer.java
@@ -56,8 +56,7 @@ public class IteratorLexer implements Lexer {
 
   @Override
   public int position() {
-    // TODO(cushon): test expression position EOF handling
-    return curr != null ? curr.position : -1;
+    return curr.position;
   }
 
   @Override

--- a/java/com/google/turbine/parse/VariableInitializerParser.java
+++ b/java/com/google/turbine/parse/VariableInitializerParser.java
@@ -205,14 +205,14 @@ public class VariableInitializerParser {
       result.add(
           ImmutableList.<SavedToken>builder()
               .addAll(tokens.subList(start, idx - 1))
-              .add(new SavedToken(Token.EOF, null, -1))
+              .add(new SavedToken(Token.EOF, null, tokens.get(idx - 1).position))
               .build());
       start = idx;
     }
     result.add(
         ImmutableList.<SavedToken>builder()
             .addAll(tokens.subList(start, tokens.size()))
-            .add(new SavedToken(Token.EOF, null, -1))
+            .add(new SavedToken(Token.EOF, null, lexer.position()))
             .build());
     return result;
   }

--- a/java/com/google/turbine/processing/ModelFactory.java
+++ b/java/com/google/turbine/processing/ModelFactory.java
@@ -94,10 +94,12 @@ class ModelFactory {
   private final Map<PackageSymbol, TurbinePackageElement> packageCache = new HashMap<>();
 
   private final ClassHierarchy cha;
+  private final ClassLoader processorLoader;
 
-  ModelFactory(Env<ClassSymbol, ? extends TypeBoundClass> env) {
+  ModelFactory(Env<ClassSymbol, ? extends TypeBoundClass> env, ClassLoader processorLoader) {
     this.env = requireNonNull(env);
     this.cha = new ClassHierarchy(env);
+    this.processorLoader = processorLoader;
   }
 
   TypeMirror asTypeMirror(Type type) {
@@ -278,5 +280,9 @@ class ModelFactory {
 
   ClassHierarchy cha() {
     return cha;
+  }
+
+  ClassLoader processorLoader() {
+    return processorLoader;
   }
 }

--- a/java/com/google/turbine/processing/TurbineAnnotationMirror.java
+++ b/java/com/google/turbine/processing/TurbineAnnotationMirror.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.turbine.binder.bound.EnumConstantValue;
+import com.google.turbine.binder.bound.TurbineAnnotationValue;
+import com.google.turbine.binder.bound.TurbineClassValue;
+import com.google.turbine.binder.bound.TypeBoundClass.MethodInfo;
+import com.google.turbine.model.Const;
+import com.google.turbine.model.Const.ArrayInitValue;
+import com.google.turbine.processing.TurbineElement.TurbineExecutableElement;
+import com.google.turbine.processing.TurbineElement.TurbineFieldElement;
+import com.google.turbine.type.AnnoInfo;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.AnnotationValueVisitor;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+
+/**
+ * An implementation of {@link AnnotationMirror} and {@link AnnotationValue} backed by {@link
+ * AnnoInfo} and {@link Const.Value}.
+ */
+class TurbineAnnotationMirror implements AnnotationMirror, AnnotationValue {
+
+  static AnnotationValue annotationValue(ModelFactory factory, Const value) {
+    switch (value.kind()) {
+      case ARRAY:
+        ImmutableList.Builder<AnnotationValue> values = ImmutableList.builder();
+        for (Const element : ((ArrayInitValue) value).elements()) {
+          values.add(annotationValue(factory, element));
+        }
+        return new TurbineArrayConstant(values.build());
+      case PRIMITIVE:
+        return (Const.Value) value;
+      case CLASS_LITERAL:
+        return new TurbineClassConstant(factory.asTypeMirror(((TurbineClassValue) value).type()));
+      case ENUM_CONSTANT:
+        return new TurbineEnumConstant(factory.fieldElement(((EnumConstantValue) value).sym()));
+      case ANNOTATION:
+        return create(factory, ((TurbineAnnotationValue) value).info());
+    }
+    throw new AssertionError(value.kind());
+  }
+
+  static TurbineAnnotationMirror create(ModelFactory factory, AnnoInfo anno) {
+    return new TurbineAnnotationMirror(factory, anno);
+  }
+
+  private final AnnoInfo anno;
+  private final Supplier<DeclaredType> type;
+  private final Supplier<ImmutableMap<String, MethodInfo>> elements;
+  private final Supplier<ImmutableMap<ExecutableElement, AnnotationValue>> elementValues;
+  private final Supplier<ImmutableMap<ExecutableElement, AnnotationValue>>
+      elementValuesWithDefaults;
+
+  private TurbineAnnotationMirror(ModelFactory factory, AnnoInfo anno) {
+    this.anno = anno;
+    this.type =
+        factory.memoize(
+            new Supplier<DeclaredType>() {
+              @Override
+              public DeclaredType get() {
+                return (DeclaredType) factory.typeElement(anno.sym()).asType();
+              }
+            });
+    this.elements =
+        factory.memoize(
+            new Supplier<ImmutableMap<String, MethodInfo>>() {
+              @Override
+              public ImmutableMap<String, MethodInfo> get() {
+                ImmutableMap.Builder<String, MethodInfo> result = ImmutableMap.builder();
+                for (MethodInfo m : factory.getSymbol(anno.sym()).methods()) {
+                  checkState(m.parameters().isEmpty());
+                  result.put(m.name(), m);
+                }
+                return result.build();
+              }
+            });
+    this.elementValues =
+        factory.memoize(
+            new Supplier<ImmutableMap<ExecutableElement, AnnotationValue>>() {
+              @Override
+              public ImmutableMap<ExecutableElement, AnnotationValue> get() {
+                ImmutableMap.Builder<ExecutableElement, AnnotationValue> result =
+                    ImmutableMap.builder();
+                for (Map.Entry<String, Const> value : anno.values().entrySet()) {
+                  result.put(
+                      factory.executableElement(elements.get().get(value.getKey()).sym()),
+                      annotationValue(factory, value.getValue()));
+                }
+                return result.build();
+              }
+            });
+    this.elementValuesWithDefaults =
+        factory.memoize(
+            new Supplier<ImmutableMap<ExecutableElement, AnnotationValue>>() {
+              @Override
+              public ImmutableMap<ExecutableElement, AnnotationValue> get() {
+                Map<ExecutableElement, AnnotationValue> result = new LinkedHashMap<>();
+                result.putAll(getElementValues());
+                for (MethodInfo method : elements.get().values()) {
+                  if (method.defaultValue() == null) {
+                    continue;
+                  }
+                  TurbineExecutableElement element = factory.executableElement(method.sym());
+                  if (result.containsKey(element)) {
+                    continue;
+                  }
+                  result.put(element, annotationValue(factory, method.defaultValue()));
+                }
+                return ImmutableMap.copyOf(result);
+              }
+            });
+  }
+
+  @Override
+  public int hashCode() {
+    return anno.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof TurbineAnnotationMirror
+        && anno.equals(((TurbineAnnotationMirror) obj).anno);
+  }
+
+  @Override
+  public String toString() {
+    return anno.toString();
+  }
+
+  @Override
+  public DeclaredType getAnnotationType() {
+    return type.get();
+  }
+
+  public Map<? extends ExecutableElement, ? extends AnnotationValue>
+      getElementValuesWithDefaults() {
+    return elementValuesWithDefaults.get();
+  }
+
+  @Override
+  public Map<? extends ExecutableElement, ? extends AnnotationValue> getElementValues() {
+    return elementValues.get();
+  }
+
+  @Override
+  public AnnotationMirror getValue() {
+    return this;
+  }
+
+  @Override
+  public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+    return v.visitAnnotation(getValue(), p);
+  }
+
+  private static class TurbineArrayConstant implements AnnotationValue {
+
+    private final ImmutableList<AnnotationValue> values;
+
+    private TurbineArrayConstant(ImmutableList<AnnotationValue> values) {
+      this.values = values;
+    }
+
+    @Override
+    public List<AnnotationValue> getValue() {
+      return values;
+    }
+
+    @Override
+    public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+      return v.visitArray(values, p);
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder sb = new StringBuilder("{");
+      Joiner.on(", ").appendTo(sb, values);
+      sb.append("}");
+      return sb.toString();
+    }
+  }
+
+  private static class TurbineClassConstant implements AnnotationValue {
+
+    private final TypeMirror value;
+
+    private TurbineClassConstant(TypeMirror value) {
+      this.value = value;
+    }
+
+    @Override
+    public TypeMirror getValue() {
+      return value;
+    }
+
+    @Override
+    public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+      return v.visitType(getValue(), p);
+    }
+
+    @Override
+    public String toString() {
+      return value + ".class";
+    }
+  }
+
+  private static class TurbineEnumConstant implements AnnotationValue {
+
+    private final TurbineFieldElement value;
+
+    private TurbineEnumConstant(TurbineFieldElement value) {
+      this.value = value;
+    }
+
+    @Override
+    public Object getValue() {
+      return value;
+    }
+
+    @Override
+    public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+      return v.visitEnumConstant(value, p);
+    }
+
+    @Override
+    public String toString() {
+      return value.getEnclosingElement() + "." + value.getSimpleName();
+    }
+  }
+}

--- a/java/com/google/turbine/processing/TurbineAnnotationProxy.java
+++ b/java/com/google/turbine/processing/TurbineAnnotationProxy.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.turbine.binder.bound.EnumConstantValue;
+import com.google.turbine.binder.bound.TurbineAnnotationValue;
+import com.google.turbine.binder.bound.TurbineClassValue;
+import com.google.turbine.binder.bound.TypeBoundClass;
+import com.google.turbine.model.Const;
+import com.google.turbine.model.Const.ArrayInitValue;
+import com.google.turbine.model.Const.Value;
+import com.google.turbine.type.AnnoInfo;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Array;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import javax.lang.model.type.MirroredTypeException;
+import javax.lang.model.type.MirroredTypesException;
+import javax.lang.model.type.TypeMirror;
+
+/** An {@link InvocationHandler} for reflectively accessing annotations. */
+class TurbineAnnotationProxy implements InvocationHandler {
+
+  static <A extends Annotation> A create(
+      ModelFactory factory, Class<A> annotationType, AnnoInfo anno) {
+    return annotationType.cast(
+        Proxy.newProxyInstance(
+            factory.processorLoader(),
+            new Class<?>[] {annotationType},
+            new TurbineAnnotationProxy(factory, annotationType, anno)));
+  }
+
+  private final ModelFactory factory;
+  private final Class<?> annotationType;
+  private final AnnoInfo anno;
+
+  TurbineAnnotationProxy(ModelFactory factory, Class<?> annotationType, AnnoInfo anno) {
+    this.factory = factory;
+    this.annotationType = annotationType;
+    this.anno = anno;
+  }
+
+  @Override
+  public Object invoke(Object proxy, Method method, Object[] args) {
+    switch (method.getName()) {
+      case "hashCode":
+        checkArgument(args == null);
+        return anno.hashCode();
+      case "annotationType":
+        checkArgument(args == null);
+        return annotationType;
+      case "equals":
+        checkArgument(args.length == 1);
+        return proxyEquals(args[0]);
+      case "toString":
+        checkArgument(args == null);
+        return anno.toString();
+      default:
+        break;
+    }
+    Const value = anno.values().get(method.getName());
+    if (value != null) {
+      return constValue(method.getReturnType(), factory, value);
+    }
+    for (TypeBoundClass.MethodInfo m : factory.getSymbol(anno.sym()).methods()) {
+      if (m.name().contentEquals(method.getName())) {
+        return constValue(method.getReturnType(), factory, m.defaultValue());
+      }
+    }
+    throw new NoSuchMethodError(method.getName());
+  }
+
+  public boolean proxyEquals(Object other) {
+    if (!annotationType.isInstance(other)) {
+      return false;
+    }
+    if (!Proxy.isProxyClass(other.getClass())) {
+      return false;
+    }
+    InvocationHandler handler = Proxy.getInvocationHandler(other);
+    if (!(handler instanceof TurbineAnnotationProxy)) {
+      return false;
+    }
+    TurbineAnnotationProxy that = (TurbineAnnotationProxy) handler;
+    return anno.equals(that.anno);
+  }
+
+  static Object constValue(Class<?> returnType, ModelFactory factory, Const value) {
+    switch (value.kind()) {
+      case PRIMITIVE:
+        return ((Value) value).getValue();
+      case ARRAY:
+        return constArrayValue(returnType, factory, (Const.ArrayInitValue) value);
+      case ENUM_CONSTANT:
+        return constEnumValue(factory.processorLoader(), (EnumConstantValue) value);
+      case ANNOTATION:
+        return constAnnotationValue(factory, (TurbineAnnotationValue) value);
+      case CLASS_LITERAL:
+        return constClassValue(factory, (TurbineClassValue) value);
+    }
+    throw new AssertionError(value.kind());
+  }
+
+  private static Object constArrayValue(
+      Class<?> returnType, ModelFactory factory, ArrayInitValue value) {
+    if (returnType.getComponentType().equals(Class.class)) {
+      List<TypeMirror> result = new ArrayList<>();
+      for (Const element : value.elements()) {
+        result.add(factory.asTypeMirror(((TurbineClassValue) element).type()));
+      }
+      throw new MirroredTypesException(result);
+    }
+    Object result = Array.newInstance(returnType.getComponentType(), value.elements().size());
+    int idx = 0;
+    for (Const element : value.elements()) {
+      Object v = constValue(returnType, factory, element);
+      Array.set(result, idx++, v);
+    }
+    return result;
+  }
+
+  @SuppressWarnings("unchecked") // Enum.class
+  private static Object constEnumValue(ClassLoader loader, EnumConstantValue value) {
+    Class<?> clazz;
+    try {
+      clazz = loader.loadClass(value.sym().owner().toString());
+    } catch (ClassNotFoundException e) {
+      throw new LinkageError(e.getMessage(), e);
+    }
+    return Enum.valueOf(clazz.asSubclass(Enum.class), value.sym().name());
+  }
+
+  private static Object constAnnotationValue(ModelFactory factory, TurbineAnnotationValue value) {
+    try {
+      String name = value.sym().binaryName().replace('/', '.');
+      Class<? extends Annotation> clazz =
+          Class.forName(name, false, factory.processorLoader()).asSubclass(Annotation.class);
+      return create(factory, clazz, value.info());
+    } catch (ClassNotFoundException e) {
+      throw new LinkageError(e.getMessage(), e);
+    }
+  }
+
+  private static Object constClassValue(ModelFactory factory, TurbineClassValue value) {
+    throw new MirroredTypeException(factory.asTypeMirror(value.type()));
+  }
+}

--- a/java/com/google/turbine/processing/TurbineElement.java
+++ b/java/com/google/turbine/processing/TurbineElement.java
@@ -35,6 +35,7 @@ import com.google.turbine.binder.sym.Symbol;
 import com.google.turbine.binder.sym.TyVarSymbol;
 import com.google.turbine.model.TurbineFlag;
 import com.google.turbine.model.TurbineTyKind;
+import com.google.turbine.type.AnnoInfo;
 import com.google.turbine.type.Type;
 import com.google.turbine.type.Type.ClassTy;
 import com.google.turbine.type.Type.ClassTy.SimpleClassTy;
@@ -93,8 +94,14 @@ public abstract class TurbineElement implements Element {
 
   @Override
   public final List<? extends AnnotationMirror> getAnnotationMirrors() {
-    throw new UnsupportedOperationException();
+    ImmutableList.Builder<AnnotationMirror> result = ImmutableList.builder();
+    for (AnnoInfo anno : annos()) {
+      result.add(TurbineAnnotationMirror.create(factory, anno));
+    }
+    return result.build();
   }
+
+  protected abstract ImmutableList<AnnoInfo> annos();
 
   /** A {@link TypeElement} implementation backed by a {@link ClassSymbol}. */
   static class TurbineTypeElement extends TurbineElement implements TypeElement {
@@ -353,6 +360,11 @@ public abstract class TurbineElement implements Element {
     public boolean equals(Object obj) {
       return obj instanceof TurbineTypeElement && sym.equals(((TurbineTypeElement) obj).sym);
     }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return info().annotations();
+    }
   }
 
   /** A {@link TypeParameterElement} implementation backed by a {@link TyVarSymbol}. */
@@ -442,6 +454,11 @@ public abstract class TurbineElement implements Element {
     @Override
     public TyVarSymbol sym() {
       return sym;
+    }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return info().annotations();
     }
   }
 
@@ -609,6 +626,11 @@ public abstract class TurbineElement implements Element {
     public <R, P> R accept(ElementVisitor<R, P> v, P p) {
       return v.visitExecutable(this, p);
     }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return info().annotations();
+    }
   }
 
   /** An {@link VariableElement} implementation backed by a {@link FieldSymbol}. */
@@ -694,6 +716,11 @@ public abstract class TurbineElement implements Element {
     @Override
     public <R, P> R accept(ElementVisitor<R, P> v, P p) {
       return v.visitVariable(this, p);
+    }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return info().annotations();
     }
   }
 
@@ -825,6 +852,12 @@ public abstract class TurbineElement implements Element {
     }
 
     @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      // TODO(cushon): load package-info annotations
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public String toString() {
       return sym.toString();
     }
@@ -921,6 +954,11 @@ public abstract class TurbineElement implements Element {
     @Override
     public String toString() {
       return String.valueOf(sym.name());
+    }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return info().annotations();
     }
   }
 }

--- a/java/com/google/turbine/processing/TurbineElement.java
+++ b/java/com/google/turbine/processing/TurbineElement.java
@@ -233,11 +233,11 @@ public abstract class TurbineElement implements Element {
                 TypeBoundClass info = info();
                 switch (info.kind()) {
                   case CLASS:
+                  case ENUM:
                     if (info.superclass() != null) {
                       return factory.asTypeMirror(info.superClassType());
                     }
                     return factory.noType();
-                  case ENUM:
                   case INTERFACE:
                   case ANNOTATION:
                     return factory.noType();

--- a/java/com/google/turbine/processing/TurbineElements.java
+++ b/java/com/google/turbine/processing/TurbineElements.java
@@ -248,8 +248,8 @@ public class TurbineElements implements Elements {
   }
 
   @Override
-  public List<? extends AnnotationMirror> getAllAnnotationMirrors(Element e) {
-    throw new UnsupportedOperationException();
+  public List<? extends AnnotationMirror> getAllAnnotationMirrors(Element element) {
+    return ((TurbineElement) element).getAllAnnotationMirrors();
   }
 
   @Override

--- a/java/com/google/turbine/processing/TurbineElements.java
+++ b/java/com/google/turbine/processing/TurbineElements.java
@@ -306,7 +306,7 @@ public class TurbineElements implements Elements {
 
   @Override
   public Name getName(CharSequence cs) {
-    throw new UnsupportedOperationException();
+    return new TurbineName(cs.toString());
   }
 
   @Override

--- a/java/com/google/turbine/processing/TurbineElements.java
+++ b/java/com/google/turbine/processing/TurbineElements.java
@@ -80,7 +80,7 @@ public class TurbineElements implements Elements {
   @Override
   public Map<? extends ExecutableElement, ? extends AnnotationValue> getElementValuesWithDefaults(
       AnnotationMirror a) {
-    throw new UnsupportedOperationException();
+    return ((TurbineAnnotationMirror) a).getElementValuesWithDefaults();
   }
 
   @Override

--- a/java/com/google/turbine/processing/TurbineElements.java
+++ b/java/com/google/turbine/processing/TurbineElements.java
@@ -28,6 +28,7 @@ import com.google.turbine.binder.sym.PackageSymbol;
 import com.google.turbine.binder.sym.ParamSymbol;
 import com.google.turbine.binder.sym.Symbol;
 import com.google.turbine.binder.sym.TyVarSymbol;
+import com.google.turbine.model.Const;
 import com.google.turbine.model.TurbineVisibility;
 import com.google.turbine.processing.TurbineElement.TurbineExecutableElement;
 import com.google.turbine.processing.TurbineElement.TurbineFieldElement;
@@ -278,7 +279,24 @@ public class TurbineElements implements Elements {
 
   @Override
   public String getConstantExpression(Object value) {
-    throw new UnsupportedOperationException();
+    if (value instanceof Byte) {
+      return new Const.ByteValue((Byte) value).toString();
+    }
+    if (value instanceof Long) {
+      return new Const.LongValue((Long) value).toString();
+    }
+    if (value instanceof Float) {
+      return new Const.FloatValue((Float) value).toString();
+    }
+    if (value instanceof Double) {
+      return new Const.DoubleValue((Double) value).toString();
+    }
+    if (value instanceof Short) {
+      // Special-case short for consistency with javac, see:
+      // https://bugs.openjdk.java.net/browse/JDK-8227617
+      return String.format("(short)%d", (Short) value);
+    }
+    return String.valueOf(value);
   }
 
   @Override

--- a/java/com/google/turbine/processing/TurbineName.java
+++ b/java/com/google/turbine/processing/TurbineName.java
@@ -23,16 +23,16 @@ import javax.lang.model.element.Name;
 /** An implementation of {@link Name} backed by a {@link CharSequence}. */
 public class TurbineName implements Name {
 
-  private final CharSequence name;
+  private final String name;
 
-  public TurbineName(CharSequence name) {
+  public TurbineName(String name) {
     requireNonNull(name);
     this.name = name;
   }
 
   @Override
   public boolean contentEquals(CharSequence cs) {
-    return name.toString().contentEquals(cs);
+    return name.contentEquals(cs);
   }
 
   @Override
@@ -52,7 +52,7 @@ public class TurbineName implements Name {
 
   @Override
   public String toString() {
-    return name.toString();
+    return name;
   }
 
   @Override

--- a/java/com/google/turbine/processing/TurbineTypeMirror.java
+++ b/java/com/google/turbine/processing/TurbineTypeMirror.java
@@ -30,6 +30,7 @@ import com.google.turbine.binder.sym.TyVarSymbol;
 import com.google.turbine.model.TurbineConstantTypeKind;
 import com.google.turbine.model.TurbineFlag;
 import com.google.turbine.model.TurbineTyKind;
+import com.google.turbine.type.AnnoInfo;
 import com.google.turbine.type.Type;
 import com.google.turbine.type.Type.ArrayTy;
 import com.google.turbine.type.Type.ClassTy;
@@ -64,9 +65,15 @@ public abstract class TurbineTypeMirror implements TypeMirror {
     this.factory = requireNonNull(factory);
   }
 
+  protected abstract ImmutableList<AnnoInfo> annos();
+
   @Override
   public final List<? extends AnnotationMirror> getAnnotationMirrors() {
-    throw new UnsupportedOperationException();
+    ImmutableList.Builder<AnnotationMirror> result = ImmutableList.builder();
+    for (AnnoInfo anno : annos()) {
+      result.add(TurbineAnnotationMirror.create(factory, anno));
+    }
+    return result.build();
   }
 
   @Override
@@ -138,6 +145,11 @@ public abstract class TurbineTypeMirror implements TypeMirror {
     @Override
     public <R, P> R accept(TypeVisitor<R, P> v, P p) {
       return v.visitPrimitive(this, p);
+    }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return type.annos();
     }
   }
 
@@ -237,6 +249,11 @@ public abstract class TurbineTypeMirror implements TypeMirror {
     public ClassTy type() {
       return type;
     }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return ImmutableList.of();
+    }
   }
 
   /** An {@link ArrayType} implementation backed by a {@link ArrayTy}. */
@@ -267,6 +284,11 @@ public abstract class TurbineTypeMirror implements TypeMirror {
     @Override
     public <R, P> R accept(TypeVisitor<R, P> v, P p) {
       return v.visitArray(this, p);
+    }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return type.annos();
     }
   }
 
@@ -310,6 +332,11 @@ public abstract class TurbineTypeMirror implements TypeMirror {
     public int hashCode() {
       return getKind().hashCode();
     }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return ImmutableList.of();
+    }
   }
 
   /** The absence of a type, {@see javax.lang.model.util.Types#getNoType}. */
@@ -348,6 +375,11 @@ public abstract class TurbineTypeMirror implements TypeMirror {
     public int hashCode() {
       return getKind().hashCode();
     }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return ImmutableList.of();
+    }
   }
 
   /** A void type, {@see javax.lang.model.util.Types#getNoType}. */
@@ -370,6 +402,11 @@ public abstract class TurbineTypeMirror implements TypeMirror {
     @Override
     public <R, P> R accept(TypeVisitor<R, P> v, P p) {
       return v.visitNoType(this, p);
+    }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return ImmutableList.of();
     }
   }
 
@@ -442,6 +479,11 @@ public abstract class TurbineTypeMirror implements TypeMirror {
     public String toString() {
       return type.toString();
     }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return type.annos();
+    }
   }
 
   /** A {@link WildcardType} implementation backed by a {@link WildTy}. */
@@ -487,6 +529,11 @@ public abstract class TurbineTypeMirror implements TypeMirror {
     @Override
     public TypeMirror getSuperBound() {
       return type.boundKind() == BoundKind.LOWER ? factory.asTypeMirror(type.bound()) : null;
+    }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return type.annotations();
     }
   }
 
@@ -550,6 +597,11 @@ public abstract class TurbineTypeMirror implements TypeMirror {
     @Override
     public String toString() {
       return Joiner.on('&').join(getBounds());
+    }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return ImmutableList.of();
     }
   }
 
@@ -623,6 +675,11 @@ public abstract class TurbineTypeMirror implements TypeMirror {
     @Override
     public <R, P> R accept(TypeVisitor<R, P> v, P p) {
       return v.visitExecutable(this, p);
+    }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return ImmutableList.of();
     }
   }
 }

--- a/javatests/com/google/turbine/binder/BinderErrorTest.java
+++ b/javatests/com/google/turbine/binder/BinderErrorTest.java
@@ -568,7 +568,26 @@ public class BinderErrorTest {
           "@One.A(b = {@One.NoSuch})",
           "                 ^",
         },
-      }
+      },
+      {
+        {
+          "public class Test {", //
+          "  @interface Anno {",
+          "    Class<?> value() default Object.class;",
+          "  }",
+          "  @Anno(NoSuch.class) int x;",
+          "  @Anno(NoSuch.class) int y;",
+          "}",
+        },
+        {
+          "<>:5: error: could not resolve NoSuch",
+          "  @Anno(NoSuch.class) int x;",
+          "        ^",
+          "<>:6: error: could not resolve NoSuch",
+          "  @Anno(NoSuch.class) int y;",
+          "        ^",
+        },
+      },
     };
     return Arrays.asList((Object[][]) testCases);
   }

--- a/javatests/com/google/turbine/binder/bytecode/BytecodeBoundClassTest.java
+++ b/javatests/com/google/turbine/binder/bytecode/BytecodeBoundClassTest.java
@@ -86,6 +86,10 @@ public class BytecodeBoundClassTest {
     <X, Y extends X, Z extends Throwable> X foo(@Deprecated X bar, Y baz) throws IOException, Z {
       return null;
     }
+
+    void baz() throws IOException {
+      throw new IOException();
+    }
   }
 
   @Test
@@ -99,6 +103,12 @@ public class BytecodeBoundClassTest {
     assertThat(m.parameters().get(0).annotations()).hasSize(1);
     assertThat(m.parameters().get(0).name()).isEqualTo("bar");
     assertThat(m.exceptions()).hasSize(2);
+
+    MethodInfo b =
+        getBytecodeBoundClass(HasMethod.class).methods().stream()
+            .filter(x -> x.name().equals("baz"))
+            .collect(onlyElement());
+    assertThat(b.exceptions()).hasSize(1);
   }
 
   @interface VoidAnno {

--- a/javatests/com/google/turbine/model/ConstTest.java
+++ b/javatests/com/google/turbine/model/ConstTest.java
@@ -131,7 +131,7 @@ public class ConstTest {
         .isEqualTo("@p.Anno(x=1, y=2)");
     assertThat(new Const.StringValue("\"").toString()).isEqualTo("\"\\\"\"");
     assertThat(new Const.ByteValue((byte) 42).toString()).isEqualTo("(byte)0x2a");
-    assertThat(new Const.ShortValue((short) 42).toString()).isEqualTo("(short)42");
+    assertThat(new Const.ShortValue((short) 42).toString()).isEqualTo("42");
   }
 
   private static String makeAnno(ImmutableMap<String, Const> value) {

--- a/javatests/com/google/turbine/parse/ParseErrorTest.java
+++ b/javatests/com/google/turbine/parse/ParseErrorTest.java
@@ -228,6 +228,23 @@ public class ParseErrorTest {
     }
   }
 
+  @Test
+  public void abruptMultivariableDeclaration() {
+    String input = "class T { int x,; }";
+    try {
+      Parser.parse(input);
+      fail("expected parsing to fail");
+    } catch (TurbineError e) {
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo(
+              lines(
+                  "<>:1: error: expected token <identifier>", //
+                  "class T { int x,; }",
+                  "                ^"));
+    }
+  }
+
   private static String lines(String... lines) {
     return Joiner.on(System.lineSeparator()).join(lines);
   }

--- a/javatests/com/google/turbine/processing/AbstractTurbineTypesTest.java
+++ b/javatests/com/google/turbine/processing/AbstractTurbineTypesTest.java
@@ -371,7 +371,7 @@ class AbstractTurbineTypesTest {
     Env<ClassSymbol, TypeBoundClass> env =
         CompoundEnv.<ClassSymbol, TypeBoundClass>of(bound.classPathEnv())
             .append(new SimpleEnv<>(bound.units()));
-    ModelFactory factory = new ModelFactory(env);
+    ModelFactory factory = new ModelFactory(env, ClassLoader.getSystemClassLoader());
     Types turbineTypes = new TurbineTypes(factory);
     ImmutableMap<String, Element> turbineElements =
         bound.units().keySet().stream()

--- a/javatests/com/google/turbine/processing/TurbineAnnotationMirrorTest.java
+++ b/javatests/com/google/turbine/processing/TurbineAnnotationMirrorTest.java
@@ -197,7 +197,7 @@ public class TurbineAnnotationMirrorTest {
     Env<ClassSymbol, TypeBoundClass> env =
         CompoundEnv.<ClassSymbol, TypeBoundClass>of(bound.classPathEnv())
             .append(new SimpleEnv<>(bound.units()));
-    ModelFactory factory = new ModelFactory(env);
+    ModelFactory factory = new ModelFactory(env, ClassLoader.getSystemClassLoader());
     TurbineTypes turbineTypes = new TurbineTypes(factory);
     TurbineElements turbineElements = new TurbineElements(factory, turbineTypes);
 

--- a/javatests/com/google/turbine/processing/TurbineAnnotationMirrorTest.java
+++ b/javatests/com/google/turbine/processing/TurbineAnnotationMirrorTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.stream.Collectors.toList;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.turbine.binder.Binder;
+import com.google.turbine.binder.ClassPathBinder;
+import com.google.turbine.binder.bound.TypeBoundClass;
+import com.google.turbine.binder.env.CompoundEnv;
+import com.google.turbine.binder.env.Env;
+import com.google.turbine.binder.env.SimpleEnv;
+import com.google.turbine.binder.sym.ClassSymbol;
+import com.google.turbine.diag.SourceFile;
+import com.google.turbine.lower.IntegrationTestSupport.TestInput;
+import com.google.turbine.parse.Parser;
+import com.google.turbine.processing.TurbineElement.TurbineTypeElement;
+import com.google.turbine.testing.TestClassPaths;
+import com.google.turbine.tree.Tree.CompUnit;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.AbstractAnnotationValueVisitor8;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TurbineAnnotationMirrorTest {
+
+  private AnnotationMirror getAnnotation(
+      List<? extends AnnotationMirror> annotationMirrors, String name) {
+    return annotationMirrors.stream()
+        .filter(x -> x.getAnnotationType().asElement().getSimpleName().contentEquals(name))
+        .findFirst()
+        .get();
+  }
+
+  private ImmutableMap<String, Object> values(AnnotationMirror a) {
+    return values(a.getElementValues());
+  }
+
+  /**
+   * Returns a map from the name of annotation elements to their values, see also {@link
+   * #getValue(AnnotationValue)}.
+   */
+  private ImmutableMap<String, Object> values(
+      Map<? extends ExecutableElement, ? extends AnnotationValue> values) {
+    return values.entrySet().stream()
+        .collect(
+            toImmutableMap(
+                e -> e.getKey().getSimpleName().toString(), e -> getValue(e.getValue())));
+  }
+
+  /**
+   * Returns the given annotation value as an Object (for primitives), or a list (for arrays), or
+   * strings (for compound annotations, enums, and class literals).
+   */
+  static Object getValue(AnnotationValue value) {
+    return value.accept(
+        new AbstractAnnotationValueVisitor8<Object, Void>() {
+          @Override
+          public Object visitBoolean(boolean b, Void unused) {
+            return b;
+          }
+
+          @Override
+          public Object visitByte(byte b, Void unused) {
+            return b;
+          }
+
+          @Override
+          public Object visitChar(char c, Void unused) {
+            return c;
+          }
+
+          @Override
+          public Object visitDouble(double d, Void unused) {
+            return d;
+          }
+
+          @Override
+          public Object visitFloat(float f, Void unused) {
+            return f;
+          }
+
+          @Override
+          public Object visitInt(int i, Void unused) {
+            return i;
+          }
+
+          @Override
+          public Object visitLong(long i, Void unused) {
+            return i;
+          }
+
+          @Override
+          public Object visitShort(short s, Void unused) {
+            return s;
+          }
+
+          @Override
+          public Object visitString(String s, Void unused) {
+            return s;
+          }
+
+          @Override
+          public Object visitType(TypeMirror t, Void unused) {
+            return value.toString();
+          }
+
+          @Override
+          public Object visitEnumConstant(VariableElement c, Void unused) {
+            return value.toString();
+          }
+
+          @Override
+          public Object visitAnnotation(AnnotationMirror a, Void unused) {
+            return value.toString();
+          }
+
+          @Override
+          public Object visitArray(List<? extends AnnotationValue> vals, Void unused) {
+            return vals.stream().map(v -> v.accept(this, null)).collect(toImmutableList());
+          }
+        },
+        null);
+  }
+
+  @Test
+  public void test() throws IOException {
+    TestInput input =
+        TestInput.parse(
+            Joiner.on('\n')
+                .join(
+                    "=== Test.java ===",
+                    "import java.lang.annotation.ElementType;",
+                    "import java.lang.annotation.Retention;",
+                    "import java.lang.annotation.RetentionPolicy;",
+                    "import java.lang.annotation.Target;",
+                    "@Retention(RetentionPolicy.RUNTIME)",
+                    "@interface A {",
+                    "  int x() default 0;",
+                    "  int y() default 1;",
+                    "  int[] z() default {};",
+                    "}",
+                    "@interface B {",
+                    "  Class<?> c() default String.class;",
+                    "  ElementType e() default ElementType.TYPE_USE;",
+                    "  A f() default @A;",
+                    "}",
+                    "@A(y = 42, z = {43})",
+                    "@B",
+                    "class Test {}",
+                    ""));
+
+    List<CompUnit> units =
+        input.sources.entrySet().stream()
+            .map(e -> new SourceFile(e.getKey(), e.getValue()))
+            .map(Parser::parse)
+            .collect(toList());
+
+    Binder.BindingResult bound =
+        Binder.bind(
+            units,
+            ClassPathBinder.bindClasspath(ImmutableList.of()),
+            TestClassPaths.TURBINE_BOOTCLASSPATH,
+            Optional.empty());
+
+    Env<ClassSymbol, TypeBoundClass> env =
+        CompoundEnv.<ClassSymbol, TypeBoundClass>of(bound.classPathEnv())
+            .append(new SimpleEnv<>(bound.units()));
+    ModelFactory factory = new ModelFactory(env);
+    TurbineTypes turbineTypes = new TurbineTypes(factory);
+    TurbineElements turbineElements = new TurbineElements(factory, turbineTypes);
+
+    TurbineTypeElement te = factory.typeElement(new ClassSymbol("Test"));
+
+    AnnotationMirror a = getAnnotation(te.getAnnotationMirrors(), "A");
+    ((TypeElement) a.getAnnotationType().asElement()).getQualifiedName().contentEquals("A");
+    assertThat(values(a)).containsExactly("y", 42, "z", ImmutableList.of(43));
+    assertThat(values(turbineElements.getElementValuesWithDefaults(a)))
+        .containsExactly(
+            "x", 0,
+            "y", 42,
+            "z", ImmutableList.of(43));
+
+    AnnotationMirror b = getAnnotation(te.getAnnotationMirrors(), "B");
+    assertThat(values(turbineElements.getElementValuesWithDefaults(b)))
+        .containsExactly(
+            "c", "java.lang.String.class",
+            "e", "java.lang.annotation.ElementType.TYPE_USE",
+            "f", "@A");
+  }
+}

--- a/javatests/com/google/turbine/processing/TurbineAnnotationProxyTest.java
+++ b/javatests/com/google/turbine/processing/TurbineAnnotationProxyTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.fail;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.base.StandardSystemProperty;
+import com.google.common.primitives.Ints;
+import com.google.common.testing.EqualsTester;
+import com.google.turbine.binder.Binder;
+import com.google.turbine.binder.ClassPathBinder;
+import com.google.turbine.binder.bound.TypeBoundClass;
+import com.google.turbine.binder.env.CompoundEnv;
+import com.google.turbine.binder.env.Env;
+import com.google.turbine.binder.env.SimpleEnv;
+import com.google.turbine.binder.sym.ClassSymbol;
+import com.google.turbine.diag.SourceFile;
+import com.google.turbine.lower.IntegrationTestSupport.TestInput;
+import com.google.turbine.parse.Parser;
+import com.google.turbine.processing.TurbineElement.TurbineTypeElement;
+import com.google.turbine.testing.TestClassPaths;
+import com.google.turbine.tree.Tree.CompUnit;
+import java.io.File;
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.MirroredTypeException;
+import javax.lang.model.type.MirroredTypesException;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TurbineAnnotationProxyTest {
+
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface A {
+    B b() default @B(-1);
+
+    ElementType e() default ElementType.PACKAGE;
+
+    int[] xs() default {};
+
+    Class<?> c() default String.class;
+
+    Class<?>[] cx() default {};
+  }
+
+  @Retention(RetentionPolicy.RUNTIME)
+  @Inherited
+  public @interface B {
+    int value();
+  }
+
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface C {}
+
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface RS {
+    R[] value() default {};
+  }
+
+  @Repeatable(RS.class)
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface R {
+    int value() default 1;
+  }
+
+  @A
+  static class I {}
+
+  @Test
+  public void test() throws IOException {
+    TestInput input =
+        TestInput.parse(
+            Joiner.on('\n')
+                .join(
+                    "=== Super.java ===",
+                    "import " + B.class.getCanonicalName() + ";",
+                    "import " + C.class.getCanonicalName() + ";",
+                    "@B(42)",
+                    "@C",
+                    "class Super {}",
+                    "=== Test.java ===",
+                    "import " + A.class.getCanonicalName() + ";",
+                    "import " + R.class.getCanonicalName() + ";",
+                    "@A(xs = {1,2,3}, cx = {Integer.class, Long.class})",
+                    "@R(1)",
+                    "@R(2)",
+                    "@R(3)",
+                    "class Test extends Super {}",
+                    ""));
+
+    List<CompUnit> units =
+        input.sources.entrySet().stream()
+            .map(e -> new SourceFile(e.getKey(), e.getValue()))
+            .map(Parser::parse)
+            .collect(toList());
+
+    Binder.BindingResult bound =
+        Binder.bind(
+            units,
+            ClassPathBinder.bindClasspath(
+                Splitter.on(File.pathSeparatorChar)
+                    .splitToList(StandardSystemProperty.JAVA_CLASS_PATH.value())
+                    .stream()
+                    .map(Paths::get)
+                    .collect(toImmutableList())),
+            TestClassPaths.TURBINE_BOOTCLASSPATH,
+            Optional.empty());
+
+    Env<ClassSymbol, TypeBoundClass> env =
+        CompoundEnv.<ClassSymbol, TypeBoundClass>of(bound.classPathEnv())
+            .append(new SimpleEnv<>(bound.units()));
+    ModelFactory factory = new ModelFactory(env, ClassLoader.getSystemClassLoader());
+    TurbineTypeElement te = factory.typeElement(new ClassSymbol("Test"));
+
+    A a = te.getAnnotation(A.class);
+    B b = te.getAnnotation(B.class);
+    assertThat(te.getAnnotation(C.class)).isNull();
+
+    assertThat(a.b().value()).isEqualTo(-1);
+    assertThat(a.e()).isEqualTo(ElementType.PACKAGE);
+    try {
+      a.c();
+      fail();
+    } catch (MirroredTypeException e) {
+      assertThat(e.getTypeMirror().getKind()).isEqualTo(TypeKind.DECLARED);
+      assertThat(getQualifiedName(e.getTypeMirror())).contains("java.lang.String");
+    }
+    try {
+      a.cx();
+      fail();
+    } catch (MirroredTypesException e) {
+      assertThat(
+              e.getTypeMirrors().stream().map(m -> getQualifiedName(m)).collect(toImmutableList()))
+          .containsExactly("java.lang.Integer", "java.lang.Long");
+    }
+    assertThat(Ints.asList(a.xs())).containsExactly(1, 2, 3).inOrder();
+    assertThat(a.annotationType()).isEqualTo(A.class);
+
+    assertThat(b.value()).isEqualTo(42);
+
+    RS container = te.getAnnotation(RS.class);
+    assertThat(container.value()).hasLength(3);
+    R[] rs = te.getAnnotationsByType(R.class);
+    assertThat(rs).hasLength(3);
+    assertThat(Arrays.toString(rs))
+        .isEqualTo(
+            String.format(
+                "[@%s(1), @%s(2), @%s(3)]",
+                R.class.getCanonicalName(),
+                R.class.getCanonicalName(),
+                R.class.getCanonicalName()));
+
+    new EqualsTester()
+        .addEqualityGroup(a, te.getAnnotation(A.class))
+        .addEqualityGroup(b, te.getAnnotation(B.class))
+        .addEqualityGroup(rs[0])
+        .addEqualityGroup(rs[1])
+        .addEqualityGroup(rs[2])
+        .addEqualityGroup(container)
+        .addEqualityGroup(I.class.getAnnotation(A.class))
+        .addEqualityGroup("unrelated")
+        .testEquals();
+  }
+
+  private static String getQualifiedName(TypeMirror typeMirror) {
+    return ((TypeElement) ((DeclaredType) typeMirror).asElement()).getQualifiedName().toString();
+  }
+}

--- a/javatests/com/google/turbine/processing/TurbineElementTest.java
+++ b/javatests/com/google/turbine/processing/TurbineElementTest.java
@@ -45,7 +45,9 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class TurbineElementTest {
 
-  private final ModelFactory factory = new ModelFactory(TestClassPaths.TURBINE_BOOTCLASSPATH.env());
+  private final ModelFactory factory =
+      new ModelFactory(
+          TestClassPaths.TURBINE_BOOTCLASSPATH.env(), ClassLoader.getSystemClassLoader());
 
   @Test
   public void typeElement() {

--- a/javatests/com/google/turbine/processing/TurbineElementTest.java
+++ b/javatests/com/google/turbine/processing/TurbineElementTest.java
@@ -84,6 +84,13 @@ public class TurbineElementTest {
                 .getQualifiedName()
                 .toString())
         .isEqualTo("java.util.AbstractMap");
+
+    e = factory.typeElement(new ClassSymbol("java/lang/annotation/ElementType"));
+    assertThat(
+            ((TypeElement) ((DeclaredType) e.getSuperclass()).asElement())
+                .getQualifiedName()
+                .toString())
+        .isEqualTo("java.lang.Enum");
   }
 
   @Test

--- a/javatests/com/google/turbine/processing/TurbineElementsGetAllMembersTest.java
+++ b/javatests/com/google/turbine/processing/TurbineElementsGetAllMembersTest.java
@@ -262,7 +262,7 @@ public class TurbineElementsGetAllMembersTest {
     Env<ClassSymbol, TypeBoundClass> env =
         CompoundEnv.<ClassSymbol, TypeBoundClass>of(bound.classPathEnv())
             .append(new SimpleEnv<>(bound.units()));
-    ModelFactory factory = new ModelFactory(env);
+    ModelFactory factory = new ModelFactory(env, ClassLoader.getSystemClassLoader());
     TurbineTypes turbineTypes = new TurbineTypes(factory);
     TurbineElements turbineElements = new TurbineElements(factory, turbineTypes);
     List<? extends Element> turbineMembers =

--- a/javatests/com/google/turbine/processing/TurbineElementsTest.java
+++ b/javatests/com/google/turbine/processing/TurbineElementsTest.java
@@ -20,11 +20,13 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.testing.EqualsTester;
 import com.google.turbine.binder.Binder.BindingResult;
 import com.google.turbine.lower.IntegrationTestSupport;
 import com.google.turbine.testing.TestClassPaths;
 import java.util.Arrays;
 import java.util.Optional;
+import javax.lang.model.element.Name;
 import javax.lang.model.util.Elements;
 import org.junit.Before;
 import org.junit.Test;
@@ -89,5 +91,23 @@ public class TurbineElementsTest {
       assertThat(turbineElements.getConstantExpression(value))
           .isEqualTo(javacElements.getConstantExpression(value));
     }
+  }
+
+  @Test
+  public void getName() {
+    Name n = turbineElements.getName("hello");
+    assertThat(n.contentEquals("hello")).isTrue();
+    assertThat(n.contentEquals("goodbye")).isFalse();
+
+    assertThat(n.toString()).isEqualTo("hello");
+    assertThat(n.toString())
+        .isEqualTo(new String(new char[] {'h', 'e', 'l', 'l', 'o'})); // defeat interning
+
+    assertThat(n.length()).isEqualTo(5);
+
+    new EqualsTester()
+        .addEqualityGroup(turbineElements.getName("hello"), turbineElements.getName("hello"))
+        .addEqualityGroup(turbineElements.getName("goodbye"))
+        .testEquals();
   }
 }

--- a/javatests/com/google/turbine/processing/TurbineElementsTest.java
+++ b/javatests/com/google/turbine/processing/TurbineElementsTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.turbine.binder.Binder.BindingResult;
+import com.google.turbine.lower.IntegrationTestSupport;
+import com.google.turbine.testing.TestClassPaths;
+import java.util.Arrays;
+import java.util.Optional;
+import javax.lang.model.util.Elements;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TurbineElementsTest {
+
+  Elements javacElements;
+  TurbineElements turbineElements;
+
+  @Before
+  public void setup() throws Exception {
+    javacElements =
+        IntegrationTestSupport.runJavacAnalysis(
+                ImmutableMap.of("Test.java", "class Test {}"),
+                ImmutableList.of(),
+                ImmutableList.of())
+            .getElements();
+
+    BindingResult bound =
+        IntegrationTestSupport.turbineAnalysis(
+            ImmutableMap.of("Test.java", "class Test {}"),
+            ImmutableList.of(),
+            TestClassPaths.TURBINE_BOOTCLASSPATH,
+            Optional.empty());
+    ModelFactory factory =
+        new ModelFactory(bound.classPathEnv(), TurbineElementsTest.class.getClassLoader());
+    TurbineTypes turbineTypes = new TurbineTypes(factory);
+    turbineElements = new TurbineElements(factory, turbineTypes);
+  }
+
+  @Test
+  public void constants() {
+    for (Object value :
+        Arrays.asList(
+            Short.valueOf((short) 1),
+            Short.MIN_VALUE,
+            Short.MAX_VALUE,
+            Byte.valueOf((byte) 1),
+            Byte.MIN_VALUE,
+            Byte.MAX_VALUE,
+            Integer.valueOf(1),
+            Integer.MIN_VALUE,
+            Integer.MAX_VALUE,
+            Long.valueOf(1),
+            Long.MIN_VALUE,
+            Long.MAX_VALUE,
+            Float.valueOf(1),
+            Float.NaN,
+            Double.NEGATIVE_INFINITY,
+            Double.POSITIVE_INFINITY,
+            Float.MAX_VALUE,
+            Float.MIN_VALUE,
+            Double.valueOf(1),
+            Double.NaN,
+            Double.NEGATIVE_INFINITY,
+            Double.POSITIVE_INFINITY,
+            Double.MAX_VALUE,
+            Double.MIN_VALUE)) {
+      assertThat(turbineElements.getConstantExpression(value))
+          .isEqualTo(javacElements.getConstantExpression(value));
+    }
+  }
+}

--- a/javatests/com/google/turbine/processing/TurbineTypeMirrorTest.java
+++ b/javatests/com/google/turbine/processing/TurbineTypeMirrorTest.java
@@ -46,7 +46,9 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class TurbineTypeMirrorTest {
 
-  private final ModelFactory factory = new ModelFactory(TestClassPaths.TURBINE_BOOTCLASSPATH.env());
+  private final ModelFactory factory =
+      new ModelFactory(
+          TestClassPaths.TURBINE_BOOTCLASSPATH.env(), ClassLoader.getSystemClassLoader());
 
   @Test
   public void primitiveTypes() {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Initial implementation of AnnotationMirror

9257f66cf3b1701652c9473679bd39c0ff3fd49e

-------

<p> Implement annotation proxies

This allows annotation processors to interact with annotations using the core
reflection APIs, as long as the annotation definitions are present on the
annotation processor classpath. To support this, we create a proxy
implementation of the annotation interface.

68df6777eb58f50ab8aa8d253eb746843c9e0382

-------

<p> Implement Elements#getConstantExpression

145bd17038f9de529c26820451af3013fd51d361

-------

<p> Implement Elements#getName

0e4a72309eec72e643a6bdcfa2d384be0e81c9f9

-------

<p> Implement Elements#getAllAnnotationMirrors

feec83794d0aaf304a40ae4e4f14c7a645d98d69

-------

<p> Don't crash if a multi-variable declaration completes abruptly

e.g. `int x,;` instead of `int x,y;`.

99d79ee70c12852352481e11e933428b2a3a09ca

-------

<p> Pass a log in to constant binding

to report errors for individual symbol resolution errors, instead of
failing on the first one. This will be helpful for supporting reduced
classpaths with annotation processing enabled.

aaa043c26334711f7d74972b987b8e5cc512a01e

-------

<p> Handle exceptions for non-generic methods

the signature is only provided for generic methods.

873a152afc1b624f131a58a8d77696defd4e7749

-------

<p> Make ShortValue#toString consistent with documentation in TurbineElements#getConstantExpression

ShortValue#toString omits to the cast to `(short)` for consistency with javac.

321a84819cd73c15f001c7df3d2cef3203f514c5

-------

<p> Memoize TurbineElement#getAnnotationMirrors

a4e124ac9d9b065fbaf6a0f2da6801d63d31884e

-------

<p> Implement TypeElement#getSuperclass for Enums

9ca25c22a237b1e925630b65defd6b9cb1ba4286