### PR TITLE
Sync master 2019/07/29

### DIFF
--- a/java/com/google/turbine/binder/ClassPath.java
+++ b/java/com/google/turbine/binder/ClassPath.java
@@ -16,6 +16,7 @@
 
 package com.google.turbine.binder;
 
+import com.google.common.base.Supplier;
 import com.google.turbine.binder.bound.ModuleInfo;
 import com.google.turbine.binder.bytecode.BytecodeBoundClass;
 import com.google.turbine.binder.env.Env;
@@ -24,7 +25,7 @@ import com.google.turbine.binder.sym.ClassSymbol;
 import com.google.turbine.binder.sym.ModuleSymbol;
 
 /**
- * A compilation classpath, e.g. the user or platform class path. Maybe backed by a search path of
+ * A compilation classpath, e.g. the user or platform class path. May be backed by a search path of
  * jar files, or a jrtfs filesystem.
  */
 public interface ClassPath {
@@ -36,4 +37,6 @@ public interface ClassPath {
 
   /** The classpath's top level index. */
   TopLevelIndex index();
+
+  Supplier<byte[]> resource(String path);
 }

--- a/java/com/google/turbine/binder/ClassPathBinder.java
+++ b/java/com/google/turbine/binder/ClassPathBinder.java
@@ -53,6 +53,7 @@ public class ClassPathBinder {
     Map<ClassSymbol, BytecodeBoundClass> transitive = new LinkedHashMap<>();
     Map<ClassSymbol, BytecodeBoundClass> map = new HashMap<>();
     Map<ModuleSymbol, ModuleInfo> modules = new HashMap<>();
+    Map<String, Supplier<byte[]>> resources = new HashMap<>();
     Env<ClassSymbol, BytecodeBoundClass> benv =
         new Env<ClassSymbol, BytecodeBoundClass>() {
           @Override
@@ -62,7 +63,7 @@ public class ClassPathBinder {
         };
     for (Path path : paths) {
       try {
-        bindJar(path, map, modules, benv, transitive);
+        bindJar(path, map, modules, benv, transitive, resources);
       } catch (IOException e) {
         throw new IOException("error reading " + path, e);
       }
@@ -89,6 +90,11 @@ public class ClassPathBinder {
       public TopLevelIndex index() {
         return index;
       }
+
+      @Override
+      public Supplier<byte[]> resource(String path) {
+        return resources.get(path);
+      }
     };
   }
 
@@ -97,12 +103,14 @@ public class ClassPathBinder {
       Map<ClassSymbol, BytecodeBoundClass> env,
       Map<ModuleSymbol, ModuleInfo> modules,
       Env<ClassSymbol, BytecodeBoundClass> benv,
-      Map<ClassSymbol, BytecodeBoundClass> transitive)
+      Map<ClassSymbol, BytecodeBoundClass> transitive,
+      Map<String, Supplier<byte[]>> resources)
       throws IOException {
     // TODO(cushon): don't leak file descriptors
     for (Zip.Entry ze : new Zip.ZipIterable(path)) {
       String name = ze.name();
       if (!name.endsWith(".class")) {
+        resources.put(name, toByteArrayOrDie(ze));
         continue;
       }
       if (name.startsWith(TRANSITIVE_PREFIX)) {

--- a/java/com/google/turbine/binder/ConstBinder.java
+++ b/java/com/google/turbine/binder/ConstBinder.java
@@ -33,6 +33,7 @@ import com.google.turbine.binder.env.Env;
 import com.google.turbine.binder.sym.ClassSymbol;
 import com.google.turbine.binder.sym.FieldSymbol;
 import com.google.turbine.binder.sym.TyVarSymbol;
+import com.google.turbine.diag.TurbineLog.TurbineLogWithSource;
 import com.google.turbine.model.Const;
 import com.google.turbine.model.Const.ArrayInitValue;
 import com.google.turbine.model.Const.Kind;
@@ -63,19 +64,29 @@ public class ConstBinder {
   private final SourceTypeBoundClass base;
   private final CompoundEnv<ClassSymbol, TypeBoundClass> env;
   private final ConstEvaluator constEvaluator;
+  private final TurbineLogWithSource log;
 
   public ConstBinder(
       Env<FieldSymbol, Value> constantEnv,
       ClassSymbol origin,
       CompoundEnv<ClassSymbol, TypeBoundClass> env,
-      SourceTypeBoundClass base) {
+      SourceTypeBoundClass base,
+      TurbineLogWithSource log) {
     this.constantEnv = constantEnv;
     this.origin = origin;
     this.base = base;
     this.env = env;
+    this.log = log;
     this.constEvaluator =
         new ConstEvaluator(
-            origin, origin, base.memberImports(), base.source(), base.scope(), constantEnv, env);
+            origin,
+            origin,
+            base.memberImports(),
+            base.source(),
+            base.scope(),
+            constantEnv,
+            env,
+            log);
   }
 
   public SourceTypeBoundClass bind() {
@@ -87,7 +98,8 @@ public class ConstBinder {
                 base.source(),
                 base.enclosingScope(),
                 constantEnv,
-                env)
+                env,
+                log)
             .evaluateAnnotations(base.annotations());
     ImmutableList<TypeBoundClass.FieldInfo> fields = fields(base.fields());
     ImmutableList<MethodInfo> methods = bindMethods(base.methods());

--- a/java/com/google/turbine/binder/ConstBinder.java
+++ b/java/com/google/turbine/binder/ConstBinder.java
@@ -336,6 +336,7 @@ public class ConstBinder {
         }
       case PRIM_TY:
       case VOID_TY:
+      case ERROR_TY:
         return type;
       case INTERSECTION_TY:
         return IntersectionTy.create(bindTypes(((IntersectionTy) type).bounds()));

--- a/java/com/google/turbine/binder/ConstEvaluator.java
+++ b/java/com/google/turbine/binder/ConstEvaluator.java
@@ -208,7 +208,7 @@ public strictfp class ConstEvaluator {
     LookupResult result = scope.lookup(new LookupKey(ImmutableList.copyOf(flat)));
     if (result == null) {
       log.error(classTy.position(), ErrorKind.CANNOT_RESOLVE, flat.peekFirst());
-      return Type.ErrorTy.create();
+      return Type.ErrorTy.create(flat);
     }
     if (result.sym().symKind() != Symbol.Kind.CLASS) {
       throw error(classTy.position(), ErrorKind.UNEXPECTED_TYPE_PARAMETER, flat.peekFirst());

--- a/java/com/google/turbine/binder/CtSymClassBinder.java
+++ b/java/com/google/turbine/binder/CtSymClassBinder.java
@@ -105,6 +105,11 @@ public class CtSymClassBinder {
       public TopLevelIndex index() {
         return index;
       }
+
+      @Override
+      public Supplier<byte[]> resource(String input) {
+        return null;
+      }
     };
   }
 

--- a/java/com/google/turbine/binder/JimageClassBinder.java
+++ b/java/com/google/turbine/binder/JimageClassBinder.java
@@ -256,5 +256,10 @@ public class JimageClassBinder {
     public TopLevelIndex index() {
       return index;
     }
+
+    @Override
+    public Supplier<byte[]> resource(String input) {
+      return null;
+    }
   }
 }

--- a/java/com/google/turbine/binder/ModuleBinder.java
+++ b/java/com/google/turbine/binder/ModuleBinder.java
@@ -40,6 +40,7 @@ import com.google.turbine.binder.sym.ClassSymbol;
 import com.google.turbine.binder.sym.ModuleSymbol;
 import com.google.turbine.diag.TurbineError;
 import com.google.turbine.diag.TurbineError.ErrorKind;
+import com.google.turbine.diag.TurbineLog.TurbineLogWithSource;
 import com.google.turbine.model.TurbineFlag;
 import com.google.turbine.tree.Tree;
 import com.google.turbine.tree.Tree.Ident;
@@ -60,8 +61,9 @@ public class ModuleBinder {
       PackageSourceBoundModule module,
       CompoundEnv<ClassSymbol, TypeBoundClass> env,
       Env<ModuleSymbol, ModuleInfo> moduleEnv,
-      Optional<String> moduleVersion) {
-    return new ModuleBinder(module, env, moduleEnv, moduleVersion).bind();
+      Optional<String> moduleVersion,
+      TurbineLogWithSource log) {
+    return new ModuleBinder(module, env, moduleEnv, moduleVersion, log).bind();
   }
 
   private final PackageSourceBoundModule module;
@@ -69,16 +71,19 @@ public class ModuleBinder {
   private final Env<ModuleSymbol, ModuleInfo> moduleEnv;
   private final Optional<String> moduleVersion;
   private final CompoundScope scope;
+  private final TurbineLogWithSource log;
 
   public ModuleBinder(
       PackageSourceBoundModule module,
       CompoundEnv<ClassSymbol, TypeBoundClass> env,
       Env<ModuleSymbol, ModuleInfo> moduleEnv,
-      Optional<String> moduleVersion) {
+      Optional<String> moduleVersion,
+      TurbineLogWithSource log) {
     this.module = module;
     this.env = env;
     this.moduleEnv = moduleEnv;
     this.moduleVersion = moduleVersion;
+    this.log = log;
     this.scope = module.scope().toScope(Resolve.resolveFunction(env, /* origin= */ null));
   }
 
@@ -92,7 +97,8 @@ public class ModuleBinder {
             module.source(),
             scope,
             /* values= */ new SimpleEnv<>(ImmutableMap.of()),
-            env);
+            env,
+            log);
     ImmutableList.Builder<AnnoInfo> annoInfos = ImmutableList.builder();
     for (Tree.Anno annoTree : module.module().annos()) {
       ClassSymbol sym = resolve(annoTree.position(), annoTree.name());

--- a/java/com/google/turbine/binder/TypeBinder.java
+++ b/java/com/google/turbine/binder/TypeBinder.java
@@ -657,7 +657,7 @@ public class TypeBinder {
     LookupResult result = scope.lookup(new LookupKey(names));
     if (result == null || result.sym() == null) {
       log.error(names.get(0).position(), ErrorKind.CANNOT_RESOLVE, Joiner.on('.').join(names));
-      return Type.ErrorTy.create();
+      return Type.ErrorTy.create(names);
     }
     Symbol sym = result.sym();
     int annoIdx = flat.size() - result.remaining().size() - 1;
@@ -669,7 +669,7 @@ public class TypeBinder {
       case TY_PARAM:
         if (!result.remaining().isEmpty()) {
           log.error(t.position(), ErrorKind.TYPE_PARAMETER_QUALIFIER);
-          return Type.ErrorTy.create();
+          return Type.ErrorTy.create(names);
         }
         return Type.TyVar.create((TyVarSymbol) sym, annos);
       default:
@@ -693,7 +693,7 @@ public class TypeBinder {
       Tree.ClassTy curr = flat.get(idx);
       sym = resolveNext(sym, curr.name());
       if (sym == null) {
-        return Type.ErrorTy.create();
+        return Type.ErrorTy.create(bits);
       }
 
       annotations = bindAnnotations(scope, curr.annos());

--- a/java/com/google/turbine/binder/TypeBinder.java
+++ b/java/com/google/turbine/binder/TypeBinder.java
@@ -396,12 +396,8 @@ public class TypeBinder {
     for (Tree.TyParam tree : trees) {
       TyVarSymbol sym = symbols.get(tree.name().value());
       ImmutableList.Builder<Type> bounds = ImmutableList.builder();
-      if (tree.bounds().isEmpty()) {
-        bounds.add(Type.ClassTy.OBJECT);
-      } else {
-        for (Tree bound : tree.bounds()) {
-          bounds.add(bindTy(scope, bound));
-        }
+      for (Tree bound : tree.bounds()) {
+        bounds.add(bindTy(scope, bound));
       }
       ImmutableList<AnnoInfo> annotations = bindAnnotations(scope, tree.annos());
       result.put(

--- a/java/com/google/turbine/binder/bound/AnnotationMetadata.java
+++ b/java/com/google/turbine/binder/bound/AnnotationMetadata.java
@@ -30,7 +30,7 @@ import java.util.EnumSet;
  */
 public class AnnotationMetadata {
 
-  private static final ImmutableSet<TurbineElementType> DEFAULT_TARGETS = getDefaultElements();
+  public static final ImmutableSet<TurbineElementType> DEFAULT_TARGETS = getDefaultElements();
 
   private static ImmutableSet<TurbineElementType> getDefaultElements() {
     EnumSet<TurbineElementType> values = EnumSet.allOf(TurbineElementType.class);

--- a/java/com/google/turbine/binder/bytecode/BytecodeBoundClass.java
+++ b/java/com/google/turbine/binder/bytecode/BytecodeBoundClass.java
@@ -443,8 +443,14 @@ public class BytecodeBoundClass implements BoundClass, HeaderBoundClass, TypeBou
     }
 
     ImmutableList.Builder<Type> exceptions = ImmutableList.builder();
-    for (TySig e : sig.exceptions()) {
-      exceptions.add(BytecodeBinder.bindTy(e, scope));
+    if (!sig.exceptions().isEmpty()) {
+      for (TySig e : sig.exceptions()) {
+        exceptions.add(BytecodeBinder.bindTy(e, scope));
+      }
+    } else {
+      for (String e : m.exceptions()) {
+        exceptions.add(ClassTy.asNonParametricClassTy(new ClassSymbol(e)));
+      }
     }
 
     Const defaultValue =

--- a/java/com/google/turbine/binder/sym/ClassSymbol.java
+++ b/java/com/google/turbine/binder/sym/ClassSymbol.java
@@ -36,6 +36,7 @@ public class ClassSymbol implements Symbol {
   public static final ClassSymbol INHERITED = new ClassSymbol("java/lang/annotation/Inherited");
   public static final ClassSymbol CLONEABLE = new ClassSymbol("java/lang/Cloneable");
   public static final ClassSymbol SERIALIZABLE = new ClassSymbol("java/io/Serializable");
+  public static final ClassSymbol DEPRECATED = new ClassSymbol("java/lang/Deprecated");
   public static final ClassSymbol ERROR = new ClassSymbol("<error>");
 
   public static final ClassSymbol CHARACTER = new ClassSymbol("java/lang/Character");

--- a/java/com/google/turbine/binder/sym/ClassSymbol.java
+++ b/java/com/google/turbine/binder/sym/ClassSymbol.java
@@ -34,6 +34,8 @@ public class ClassSymbol implements Symbol {
   public static final ClassSymbol ENUM = new ClassSymbol("java/lang/Enum");
   public static final ClassSymbol ANNOTATION = new ClassSymbol("java/lang/annotation/Annotation");
   public static final ClassSymbol INHERITED = new ClassSymbol("java/lang/annotation/Inherited");
+  public static final ClassSymbol CLONEABLE = new ClassSymbol("java/lang/Cloneable");
+  public static final ClassSymbol SERIALIZABLE = new ClassSymbol("java/io/Serializable");
   public static final ClassSymbol ERROR = new ClassSymbol("<error>");
 
   public static final ClassSymbol CHARACTER = new ClassSymbol("java/lang/Character");

--- a/java/com/google/turbine/binder/sym/ClassSymbol.java
+++ b/java/com/google/turbine/binder/sym/ClassSymbol.java
@@ -33,6 +33,7 @@ public class ClassSymbol implements Symbol {
   public static final ClassSymbol STRING = new ClassSymbol("java/lang/String");
   public static final ClassSymbol ENUM = new ClassSymbol("java/lang/Enum");
   public static final ClassSymbol ANNOTATION = new ClassSymbol("java/lang/annotation/Annotation");
+  public static final ClassSymbol INHERITED = new ClassSymbol("java/lang/annotation/Inherited");
   public static final ClassSymbol ERROR = new ClassSymbol("<error>");
 
   public static final ClassSymbol CHARACTER = new ClassSymbol("java/lang/Character");

--- a/java/com/google/turbine/model/Const.java
+++ b/java/com/google/turbine/model/Const.java
@@ -415,6 +415,9 @@ public abstract class Const {
 
     @Override
     public String toString() {
+      if (Float.isNaN(value)) {
+        return "0.0f/0.0f";
+      }
       return value + "f";
     }
 
@@ -498,6 +501,15 @@ public abstract class Const {
 
     @Override
     public String toString() {
+      if (Double.isNaN(value)) {
+        return "0.0/0.0";
+      }
+      if (value == Double.POSITIVE_INFINITY) {
+        return "1.0/0.0";
+      }
+      if (value == Double.NEGATIVE_INFINITY) {
+        return "-1.0/0.0";
+      }
       return String.valueOf(value);
     }
 

--- a/java/com/google/turbine/model/Const.java
+++ b/java/com/google/turbine/model/Const.java
@@ -641,7 +641,7 @@ public abstract class Const {
 
     @Override
     public String toString() {
-      return String.format("(short)%d", value);
+      return String.valueOf(value);
     }
 
     @Override

--- a/java/com/google/turbine/model/Const.java
+++ b/java/com/google/turbine/model/Const.java
@@ -19,6 +19,8 @@ package com.google.turbine.model;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.escape.SourceCodeEscapers;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.AnnotationValueVisitor;
 
 /**
  * Compile-time constant expressions, including literals of primitive or String type, class
@@ -55,7 +57,7 @@ public abstract class Const {
   }
 
   /** Subtypes of {@link Const} for primitive and String literals. */
-  public abstract static class Value extends Const {
+  public abstract static class Value extends Const implements AnnotationValue {
     public abstract TurbineConstantTypeKind constantTypeKind();
 
     @Override
@@ -114,11 +116,21 @@ public abstract class Const {
     }
 
     @Override
+    public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+      return v.visitBoolean(value, p);
+    }
+
+    @Override
     public TurbineConstantTypeKind constantTypeKind() {
       return TurbineConstantTypeKind.BOOLEAN;
     }
 
     public boolean value() {
+      return value;
+    }
+
+    @Override
+    public Object getValue() {
       return value;
     }
 
@@ -158,11 +170,21 @@ public abstract class Const {
     }
 
     @Override
+    public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+      return v.visitInt(value, p);
+    }
+
+    @Override
     public TurbineConstantTypeKind constantTypeKind() {
       return TurbineConstantTypeKind.INT;
     }
 
     public int value() {
+      return value;
+    }
+
+    @Override
+    public Object getValue() {
       return value;
     }
 
@@ -231,11 +253,21 @@ public abstract class Const {
     }
 
     @Override
+    public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+      return v.visitLong(value, p);
+    }
+
+    @Override
     public TurbineConstantTypeKind constantTypeKind() {
       return TurbineConstantTypeKind.LONG;
     }
 
     public long value() {
+      return value;
+    }
+
+    @Override
+    public Object getValue() {
       return value;
     }
 
@@ -304,11 +336,21 @@ public abstract class Const {
     }
 
     @Override
+    public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+      return v.visitChar(value, p);
+    }
+
+    @Override
     public TurbineConstantTypeKind constantTypeKind() {
       return TurbineConstantTypeKind.CHAR;
     }
 
     public char value() {
+      return value;
+    }
+
+    @Override
+    public Object getValue() {
       return value;
     }
 
@@ -377,11 +419,21 @@ public abstract class Const {
     }
 
     @Override
+    public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+      return v.visitFloat(value, p);
+    }
+
+    @Override
     public TurbineConstantTypeKind constantTypeKind() {
       return TurbineConstantTypeKind.FLOAT;
     }
 
     public float value() {
+      return value;
+    }
+
+    @Override
+    public Object getValue() {
       return value;
     }
 
@@ -450,11 +502,21 @@ public abstract class Const {
     }
 
     @Override
+    public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+      return v.visitDouble(value, p);
+    }
+
+    @Override
     public TurbineConstantTypeKind constantTypeKind() {
       return TurbineConstantTypeKind.DOUBLE;
     }
 
     public double value() {
+      return value;
+    }
+
+    @Override
+    public Object getValue() {
       return value;
     }
 
@@ -523,11 +585,21 @@ public abstract class Const {
     }
 
     @Override
+    public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+      return v.visitString(value, p);
+    }
+
+    @Override
     public TurbineConstantTypeKind constantTypeKind() {
       return TurbineConstantTypeKind.STRING;
     }
 
     public String value() {
+      return value;
+    }
+
+    @Override
+    public Object getValue() {
       return value;
     }
 
@@ -561,11 +633,21 @@ public abstract class Const {
     }
 
     @Override
+    public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+      return v.visitShort(value, p);
+    }
+
+    @Override
     public TurbineConstantTypeKind constantTypeKind() {
       return TurbineConstantTypeKind.SHORT;
     }
 
     public short value() {
+      return value;
+    }
+
+    @Override
+    public Object getValue() {
       return value;
     }
 
@@ -639,6 +721,11 @@ public abstract class Const {
     }
 
     @Override
+    public Object getValue() {
+      return value;
+    }
+
+    @Override
     public IntValue asInteger() {
       return new IntValue((int) value);
     }
@@ -691,6 +778,11 @@ public abstract class Const {
     @Override
     public String toString() {
       return String.format("(byte)0x%02x", value);
+    }
+
+    @Override
+    public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+      return v.visitByte(value, p);
     }
   }
 

--- a/java/com/google/turbine/parse/IteratorLexer.java
+++ b/java/com/google/turbine/parse/IteratorLexer.java
@@ -56,8 +56,7 @@ public class IteratorLexer implements Lexer {
 
   @Override
   public int position() {
-    // TODO(cushon): test expression position EOF handling
-    return curr != null ? curr.position : -1;
+    return curr.position;
   }
 
   @Override

--- a/java/com/google/turbine/parse/VariableInitializerParser.java
+++ b/java/com/google/turbine/parse/VariableInitializerParser.java
@@ -205,14 +205,14 @@ public class VariableInitializerParser {
       result.add(
           ImmutableList.<SavedToken>builder()
               .addAll(tokens.subList(start, idx - 1))
-              .add(new SavedToken(Token.EOF, null, -1))
+              .add(new SavedToken(Token.EOF, null, tokens.get(idx - 1).position))
               .build());
       start = idx;
     }
     result.add(
         ImmutableList.<SavedToken>builder()
             .addAll(tokens.subList(start, tokens.size()))
-            .add(new SavedToken(Token.EOF, null, -1))
+            .add(new SavedToken(Token.EOF, null, lexer.position()))
             .build());
     return result;
   }

--- a/java/com/google/turbine/processing/ModelFactory.java
+++ b/java/com/google/turbine/processing/ModelFactory.java
@@ -138,10 +138,14 @@ class ModelFactory {
         return new TurbineTypeVariable(this, (TyVar) type);
       case INTERSECTION_TY:
         IntersectionTy intersectionTy = (IntersectionTy) type;
-        if (intersectionTy.bounds().size() == 1) {
-          return createTypeMirror(getOnlyElement(intersectionTy.bounds()));
+        switch (intersectionTy.bounds().size()) {
+          case 0:
+            return createTypeMirror(ClassTy.OBJECT);
+          case 1:
+            return createTypeMirror(getOnlyElement(intersectionTy.bounds()));
+          default:
+            return new TurbineIntersectionType(this, intersectionTy);
         }
-        return new TurbineIntersectionType(this, intersectionTy);
       case NONE_TY:
         return new TurbineNoType(this);
       case METHOD_TY:
@@ -152,7 +156,7 @@ class ModelFactory {
   }
 
   /** Creates a list of {@link TurbineTypeMirror}s backed by the given {@link Type}s. */
-  ImmutableList<TypeMirror> asTypeMirrors(ImmutableList<? extends Type> types) {
+  ImmutableList<TypeMirror> asTypeMirrors(Iterable<? extends Type> types) {
     ImmutableList.Builder<TypeMirror> result = ImmutableList.builder();
     for (Type type : types) {
       result.add(asTypeMirror(type));

--- a/java/com/google/turbine/processing/ModelFactory.java
+++ b/java/com/google/turbine/processing/ModelFactory.java
@@ -94,10 +94,12 @@ class ModelFactory {
   private final Map<PackageSymbol, TurbinePackageElement> packageCache = new HashMap<>();
 
   private final ClassHierarchy cha;
+  private final ClassLoader processorLoader;
 
-  ModelFactory(Env<ClassSymbol, ? extends TypeBoundClass> env) {
+  ModelFactory(Env<ClassSymbol, ? extends TypeBoundClass> env, ClassLoader processorLoader) {
     this.env = requireNonNull(env);
     this.cha = new ClassHierarchy(env);
+    this.processorLoader = processorLoader;
   }
 
   TypeMirror asTypeMirror(Type type) {
@@ -278,5 +280,9 @@ class ModelFactory {
 
   ClassHierarchy cha() {
     return cha;
+  }
+
+  ClassLoader processorLoader() {
+    return processorLoader;
   }
 }

--- a/java/com/google/turbine/processing/TurbineAnnotationMirror.java
+++ b/java/com/google/turbine/processing/TurbineAnnotationMirror.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.turbine.binder.bound.EnumConstantValue;
+import com.google.turbine.binder.bound.TurbineAnnotationValue;
+import com.google.turbine.binder.bound.TurbineClassValue;
+import com.google.turbine.binder.bound.TypeBoundClass.MethodInfo;
+import com.google.turbine.model.Const;
+import com.google.turbine.model.Const.ArrayInitValue;
+import com.google.turbine.processing.TurbineElement.TurbineExecutableElement;
+import com.google.turbine.processing.TurbineElement.TurbineFieldElement;
+import com.google.turbine.type.AnnoInfo;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.AnnotationValueVisitor;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+
+/**
+ * An implementation of {@link AnnotationMirror} and {@link AnnotationValue} backed by {@link
+ * AnnoInfo} and {@link Const.Value}.
+ */
+class TurbineAnnotationMirror implements AnnotationMirror, AnnotationValue {
+
+  static AnnotationValue annotationValue(ModelFactory factory, Const value) {
+    switch (value.kind()) {
+      case ARRAY:
+        ImmutableList.Builder<AnnotationValue> values = ImmutableList.builder();
+        for (Const element : ((ArrayInitValue) value).elements()) {
+          values.add(annotationValue(factory, element));
+        }
+        return new TurbineArrayConstant(values.build());
+      case PRIMITIVE:
+        return (Const.Value) value;
+      case CLASS_LITERAL:
+        return new TurbineClassConstant(factory.asTypeMirror(((TurbineClassValue) value).type()));
+      case ENUM_CONSTANT:
+        return new TurbineEnumConstant(factory.fieldElement(((EnumConstantValue) value).sym()));
+      case ANNOTATION:
+        return create(factory, ((TurbineAnnotationValue) value).info());
+    }
+    throw new AssertionError(value.kind());
+  }
+
+  static TurbineAnnotationMirror create(ModelFactory factory, AnnoInfo anno) {
+    return new TurbineAnnotationMirror(factory, anno);
+  }
+
+  private final AnnoInfo anno;
+  private final Supplier<DeclaredType> type;
+  private final Supplier<ImmutableMap<String, MethodInfo>> elements;
+  private final Supplier<ImmutableMap<ExecutableElement, AnnotationValue>> elementValues;
+  private final Supplier<ImmutableMap<ExecutableElement, AnnotationValue>>
+      elementValuesWithDefaults;
+
+  private TurbineAnnotationMirror(ModelFactory factory, AnnoInfo anno) {
+    this.anno = anno;
+    this.type =
+        factory.memoize(
+            new Supplier<DeclaredType>() {
+              @Override
+              public DeclaredType get() {
+                return (DeclaredType) factory.typeElement(anno.sym()).asType();
+              }
+            });
+    this.elements =
+        factory.memoize(
+            new Supplier<ImmutableMap<String, MethodInfo>>() {
+              @Override
+              public ImmutableMap<String, MethodInfo> get() {
+                ImmutableMap.Builder<String, MethodInfo> result = ImmutableMap.builder();
+                for (MethodInfo m : factory.getSymbol(anno.sym()).methods()) {
+                  checkState(m.parameters().isEmpty());
+                  result.put(m.name(), m);
+                }
+                return result.build();
+              }
+            });
+    this.elementValues =
+        factory.memoize(
+            new Supplier<ImmutableMap<ExecutableElement, AnnotationValue>>() {
+              @Override
+              public ImmutableMap<ExecutableElement, AnnotationValue> get() {
+                ImmutableMap.Builder<ExecutableElement, AnnotationValue> result =
+                    ImmutableMap.builder();
+                for (Map.Entry<String, Const> value : anno.values().entrySet()) {
+                  result.put(
+                      factory.executableElement(elements.get().get(value.getKey()).sym()),
+                      annotationValue(factory, value.getValue()));
+                }
+                return result.build();
+              }
+            });
+    this.elementValuesWithDefaults =
+        factory.memoize(
+            new Supplier<ImmutableMap<ExecutableElement, AnnotationValue>>() {
+              @Override
+              public ImmutableMap<ExecutableElement, AnnotationValue> get() {
+                Map<ExecutableElement, AnnotationValue> result = new LinkedHashMap<>();
+                result.putAll(getElementValues());
+                for (MethodInfo method : elements.get().values()) {
+                  if (method.defaultValue() == null) {
+                    continue;
+                  }
+                  TurbineExecutableElement element = factory.executableElement(method.sym());
+                  if (result.containsKey(element)) {
+                    continue;
+                  }
+                  result.put(element, annotationValue(factory, method.defaultValue()));
+                }
+                return ImmutableMap.copyOf(result);
+              }
+            });
+  }
+
+  @Override
+  public int hashCode() {
+    return anno.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof TurbineAnnotationMirror
+        && anno.equals(((TurbineAnnotationMirror) obj).anno);
+  }
+
+  @Override
+  public String toString() {
+    return anno.toString();
+  }
+
+  @Override
+  public DeclaredType getAnnotationType() {
+    return type.get();
+  }
+
+  public Map<? extends ExecutableElement, ? extends AnnotationValue>
+      getElementValuesWithDefaults() {
+    return elementValuesWithDefaults.get();
+  }
+
+  @Override
+  public Map<? extends ExecutableElement, ? extends AnnotationValue> getElementValues() {
+    return elementValues.get();
+  }
+
+  @Override
+  public AnnotationMirror getValue() {
+    return this;
+  }
+
+  @Override
+  public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+    return v.visitAnnotation(getValue(), p);
+  }
+
+  private static class TurbineArrayConstant implements AnnotationValue {
+
+    private final ImmutableList<AnnotationValue> values;
+
+    private TurbineArrayConstant(ImmutableList<AnnotationValue> values) {
+      this.values = values;
+    }
+
+    @Override
+    public List<AnnotationValue> getValue() {
+      return values;
+    }
+
+    @Override
+    public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+      return v.visitArray(values, p);
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder sb = new StringBuilder("{");
+      Joiner.on(", ").appendTo(sb, values);
+      sb.append("}");
+      return sb.toString();
+    }
+  }
+
+  private static class TurbineClassConstant implements AnnotationValue {
+
+    private final TypeMirror value;
+
+    private TurbineClassConstant(TypeMirror value) {
+      this.value = value;
+    }
+
+    @Override
+    public TypeMirror getValue() {
+      return value;
+    }
+
+    @Override
+    public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+      return v.visitType(getValue(), p);
+    }
+
+    @Override
+    public String toString() {
+      return value + ".class";
+    }
+  }
+
+  private static class TurbineEnumConstant implements AnnotationValue {
+
+    private final TurbineFieldElement value;
+
+    private TurbineEnumConstant(TurbineFieldElement value) {
+      this.value = value;
+    }
+
+    @Override
+    public Object getValue() {
+      return value;
+    }
+
+    @Override
+    public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+      return v.visitEnumConstant(value, p);
+    }
+
+    @Override
+    public String toString() {
+      return value.getEnclosingElement() + "." + value.getSimpleName();
+    }
+  }
+}

--- a/java/com/google/turbine/processing/TurbineAnnotationProxy.java
+++ b/java/com/google/turbine/processing/TurbineAnnotationProxy.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.turbine.binder.bound.EnumConstantValue;
+import com.google.turbine.binder.bound.TurbineAnnotationValue;
+import com.google.turbine.binder.bound.TurbineClassValue;
+import com.google.turbine.binder.bound.TypeBoundClass;
+import com.google.turbine.model.Const;
+import com.google.turbine.model.Const.ArrayInitValue;
+import com.google.turbine.model.Const.Value;
+import com.google.turbine.type.AnnoInfo;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Array;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import javax.lang.model.type.MirroredTypeException;
+import javax.lang.model.type.MirroredTypesException;
+import javax.lang.model.type.TypeMirror;
+
+/** An {@link InvocationHandler} for reflectively accessing annotations. */
+class TurbineAnnotationProxy implements InvocationHandler {
+
+  static <A extends Annotation> A create(
+      ModelFactory factory, Class<A> annotationType, AnnoInfo anno) {
+    return annotationType.cast(
+        Proxy.newProxyInstance(
+            factory.processorLoader(),
+            new Class<?>[] {annotationType},
+            new TurbineAnnotationProxy(factory, annotationType, anno)));
+  }
+
+  private final ModelFactory factory;
+  private final Class<?> annotationType;
+  private final AnnoInfo anno;
+
+  TurbineAnnotationProxy(ModelFactory factory, Class<?> annotationType, AnnoInfo anno) {
+    this.factory = factory;
+    this.annotationType = annotationType;
+    this.anno = anno;
+  }
+
+  @Override
+  public Object invoke(Object proxy, Method method, Object[] args) {
+    switch (method.getName()) {
+      case "hashCode":
+        checkArgument(args == null);
+        return anno.hashCode();
+      case "annotationType":
+        checkArgument(args == null);
+        return annotationType;
+      case "equals":
+        checkArgument(args.length == 1);
+        return proxyEquals(args[0]);
+      case "toString":
+        checkArgument(args == null);
+        return anno.toString();
+      default:
+        break;
+    }
+    Const value = anno.values().get(method.getName());
+    if (value != null) {
+      return constValue(method.getReturnType(), factory, value);
+    }
+    for (TypeBoundClass.MethodInfo m : factory.getSymbol(anno.sym()).methods()) {
+      if (m.name().contentEquals(method.getName())) {
+        return constValue(method.getReturnType(), factory, m.defaultValue());
+      }
+    }
+    throw new NoSuchMethodError(method.getName());
+  }
+
+  public boolean proxyEquals(Object other) {
+    if (!annotationType.isInstance(other)) {
+      return false;
+    }
+    if (!Proxy.isProxyClass(other.getClass())) {
+      return false;
+    }
+    InvocationHandler handler = Proxy.getInvocationHandler(other);
+    if (!(handler instanceof TurbineAnnotationProxy)) {
+      return false;
+    }
+    TurbineAnnotationProxy that = (TurbineAnnotationProxy) handler;
+    return anno.equals(that.anno);
+  }
+
+  static Object constValue(Class<?> returnType, ModelFactory factory, Const value) {
+    switch (value.kind()) {
+      case PRIMITIVE:
+        return ((Value) value).getValue();
+      case ARRAY:
+        return constArrayValue(returnType, factory, (Const.ArrayInitValue) value);
+      case ENUM_CONSTANT:
+        return constEnumValue(factory.processorLoader(), (EnumConstantValue) value);
+      case ANNOTATION:
+        return constAnnotationValue(factory, (TurbineAnnotationValue) value);
+      case CLASS_LITERAL:
+        return constClassValue(factory, (TurbineClassValue) value);
+    }
+    throw new AssertionError(value.kind());
+  }
+
+  private static Object constArrayValue(
+      Class<?> returnType, ModelFactory factory, ArrayInitValue value) {
+    if (returnType.getComponentType().equals(Class.class)) {
+      List<TypeMirror> result = new ArrayList<>();
+      for (Const element : value.elements()) {
+        result.add(factory.asTypeMirror(((TurbineClassValue) element).type()));
+      }
+      throw new MirroredTypesException(result);
+    }
+    Object result = Array.newInstance(returnType.getComponentType(), value.elements().size());
+    int idx = 0;
+    for (Const element : value.elements()) {
+      Object v = constValue(returnType, factory, element);
+      Array.set(result, idx++, v);
+    }
+    return result;
+  }
+
+  @SuppressWarnings("unchecked") // Enum.class
+  private static Object constEnumValue(ClassLoader loader, EnumConstantValue value) {
+    Class<?> clazz;
+    try {
+      clazz = loader.loadClass(value.sym().owner().toString());
+    } catch (ClassNotFoundException e) {
+      throw new LinkageError(e.getMessage(), e);
+    }
+    return Enum.valueOf(clazz.asSubclass(Enum.class), value.sym().name());
+  }
+
+  private static Object constAnnotationValue(ModelFactory factory, TurbineAnnotationValue value) {
+    try {
+      String name = value.sym().binaryName().replace('/', '.');
+      Class<? extends Annotation> clazz =
+          Class.forName(name, false, factory.processorLoader()).asSubclass(Annotation.class);
+      return create(factory, clazz, value.info());
+    } catch (ClassNotFoundException e) {
+      throw new LinkageError(e.getMessage(), e);
+    }
+  }
+
+  private static Object constClassValue(ModelFactory factory, TurbineClassValue value) {
+    throw new MirroredTypeException(factory.asTypeMirror(value.type()));
+  }
+}

--- a/java/com/google/turbine/processing/TurbineElement.java
+++ b/java/com/google/turbine/processing/TurbineElement.java
@@ -812,7 +812,10 @@ public abstract class TurbineElement implements Element {
 
     @Override
     public Object getConstantValue() {
-      throw new UnsupportedOperationException();
+      if (info().value() == null) {
+        return null;
+      }
+      return info().value().getValue();
     }
 
     @Override

--- a/java/com/google/turbine/processing/TurbineElement.java
+++ b/java/com/google/turbine/processing/TurbineElement.java
@@ -544,7 +544,8 @@ public abstract class TurbineElement implements Element {
 
     @Override
     public List<? extends TypeMirror> getBounds() {
-      return factory.asTypeMirrors(info().upperBound().bounds());
+      ImmutableList<Type> bounds = info().upperBound().bounds();
+      return factory.asTypeMirrors(bounds.isEmpty() ? ImmutableList.of(ClassTy.OBJECT) : bounds);
     }
 
     @Override

--- a/java/com/google/turbine/processing/TurbineElement.java
+++ b/java/com/google/turbine/processing/TurbineElement.java
@@ -35,6 +35,7 @@ import com.google.turbine.binder.sym.Symbol;
 import com.google.turbine.binder.sym.TyVarSymbol;
 import com.google.turbine.model.TurbineFlag;
 import com.google.turbine.model.TurbineTyKind;
+import com.google.turbine.type.AnnoInfo;
 import com.google.turbine.type.Type;
 import com.google.turbine.type.Type.ClassTy;
 import com.google.turbine.type.Type.ClassTy.SimpleClassTy;
@@ -93,8 +94,14 @@ public abstract class TurbineElement implements Element {
 
   @Override
   public final List<? extends AnnotationMirror> getAnnotationMirrors() {
-    throw new UnsupportedOperationException();
+    ImmutableList.Builder<AnnotationMirror> result = ImmutableList.builder();
+    for (AnnoInfo anno : annos()) {
+      result.add(TurbineAnnotationMirror.create(factory, anno));
+    }
+    return result.build();
   }
+
+  protected abstract ImmutableList<AnnoInfo> annos();
 
   /** A {@link TypeElement} implementation backed by a {@link ClassSymbol}. */
   static class TurbineTypeElement extends TurbineElement implements TypeElement {
@@ -353,6 +360,11 @@ public abstract class TurbineElement implements Element {
     public boolean equals(Object obj) {
       return obj instanceof TurbineTypeElement && sym.equals(((TurbineTypeElement) obj).sym);
     }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return info().annotations();
+    }
   }
 
   /** A {@link TypeParameterElement} implementation backed by a {@link TyVarSymbol}. */
@@ -442,6 +454,11 @@ public abstract class TurbineElement implements Element {
     @Override
     public TyVarSymbol sym() {
       return sym;
+    }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return info().annotations();
     }
   }
 
@@ -609,6 +626,11 @@ public abstract class TurbineElement implements Element {
     public <R, P> R accept(ElementVisitor<R, P> v, P p) {
       return v.visitExecutable(this, p);
     }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return info().annotations();
+    }
   }
 
   /** An {@link VariableElement} implementation backed by a {@link FieldSymbol}. */
@@ -694,6 +716,11 @@ public abstract class TurbineElement implements Element {
     @Override
     public <R, P> R accept(ElementVisitor<R, P> v, P p) {
       return v.visitVariable(this, p);
+    }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return info().annotations();
     }
   }
 
@@ -825,6 +852,12 @@ public abstract class TurbineElement implements Element {
     }
 
     @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      // TODO(cushon): load package-info annotations
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public String toString() {
       return sym.toString();
     }
@@ -921,6 +954,11 @@ public abstract class TurbineElement implements Element {
     @Override
     public String toString() {
       return String.valueOf(sym.name());
+    }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return info().annotations();
     }
   }
 }

--- a/java/com/google/turbine/processing/TurbineElement.java
+++ b/java/com/google/turbine/processing/TurbineElement.java
@@ -372,11 +372,9 @@ public abstract class TurbineElement implements Element {
             new Supplier<Element>() {
               @Override
               public Element get() {
-                TypeBoundClass info = info();
-                if (info != null && info.owner() != null) {
-                  return factory.typeElement(info.owner());
-                }
-                return factory.packageElement(sym.owner());
+                return getNestingKind().equals(NestingKind.TOP_LEVEL)
+                    ? factory.packageElement(sym.owner())
+                    : factory.typeElement(info().owner());
               }
             });
 

--- a/java/com/google/turbine/processing/TurbineElement.java
+++ b/java/com/google/turbine/processing/TurbineElement.java
@@ -715,7 +715,9 @@ public abstract class TurbineElement implements Element {
 
     @Override
     public AnnotationValue getDefaultValue() {
-      throw new UnsupportedOperationException();
+      return info().defaultValue() != null
+          ? TurbineAnnotationMirror.annotationValue(factory, info().defaultValue())
+          : null;
     }
 
     @Override

--- a/java/com/google/turbine/processing/TurbineElement.java
+++ b/java/com/google/turbine/processing/TurbineElement.java
@@ -21,7 +21,9 @@ import static java.util.Objects.requireNonNull;
 import com.google.common.base.Joiner;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
 import com.google.turbine.binder.bound.AnnotationMetadata;
 import com.google.turbine.binder.bound.TurbineAnnotationValue;
 import com.google.turbine.binder.bound.TypeBoundClass;
@@ -560,7 +562,7 @@ public abstract class TurbineElement implements Element {
 
     @Override
     public Set<Modifier> getModifiers() {
-      return EnumSet.noneOf(Modifier.class);
+      return ImmutableSet.of();
     }
 
     @Override
@@ -868,7 +870,7 @@ public abstract class TurbineElement implements Element {
     METHOD
   }
 
-  private static EnumSet<Modifier> asModifierSet(ModifierOwner modifierOwner, int access) {
+  private static ImmutableSet<Modifier> asModifierSet(ModifierOwner modifierOwner, int access) {
     EnumSet<Modifier> modifiers = EnumSet.noneOf(Modifier.class);
     if ((access & TurbineFlag.ACC_PUBLIC) == TurbineFlag.ACC_PUBLIC) {
       modifiers.add(Modifier.PUBLIC);
@@ -914,7 +916,7 @@ public abstract class TurbineElement implements Element {
       modifiers.add(Modifier.STRICTFP);
     }
 
-    return modifiers;
+    return Sets.immutableEnumSet(modifiers);
   }
 
   /** A {@link PackageElement} implementation backed by a {@link PackageSymbol}. */
@@ -949,7 +951,7 @@ public abstract class TurbineElement implements Element {
 
     @Override
     public Set<Modifier> getModifiers() {
-      return EnumSet.noneOf(Modifier.class);
+      return ImmutableSet.of();
     }
 
     @Override

--- a/java/com/google/turbine/processing/TurbineElement.java
+++ b/java/com/google/turbine/processing/TurbineElement.java
@@ -233,11 +233,11 @@ public abstract class TurbineElement implements Element {
                 TypeBoundClass info = info();
                 switch (info.kind()) {
                   case CLASS:
+                  case ENUM:
                     if (info.superclass() != null) {
                       return factory.asTypeMirror(info.superClassType());
                     }
                     return factory.noType();
-                  case ENUM:
                   case INTERFACE:
                   case ANNOTATION:
                     return factory.noType();

--- a/java/com/google/turbine/processing/TurbineElements.java
+++ b/java/com/google/turbine/processing/TurbineElements.java
@@ -248,8 +248,8 @@ public class TurbineElements implements Elements {
   }
 
   @Override
-  public List<? extends AnnotationMirror> getAllAnnotationMirrors(Element e) {
-    throw new UnsupportedOperationException();
+  public List<? extends AnnotationMirror> getAllAnnotationMirrors(Element element) {
+    return ((TurbineElement) element).getAllAnnotationMirrors();
   }
 
   @Override

--- a/java/com/google/turbine/processing/TurbineElements.java
+++ b/java/com/google/turbine/processing/TurbineElements.java
@@ -306,7 +306,7 @@ public class TurbineElements implements Elements {
 
   @Override
   public Name getName(CharSequence cs) {
-    throw new UnsupportedOperationException();
+    return new TurbineName(cs.toString());
   }
 
   @Override

--- a/java/com/google/turbine/processing/TurbineElements.java
+++ b/java/com/google/turbine/processing/TurbineElements.java
@@ -75,7 +75,14 @@ public class TurbineElements implements Elements {
 
   @Override
   public TypeElement getTypeElement(CharSequence name) {
-    throw new UnsupportedOperationException();
+    ClassSymbol sym = factory.inferSymbol(name);
+    if (sym == null) {
+      return null;
+    }
+    if (factory.getSymbol(sym) == null) {
+      return null;
+    }
+    return factory.typeElement(sym);
   }
 
   @Override

--- a/java/com/google/turbine/processing/TurbineElements.java
+++ b/java/com/google/turbine/processing/TurbineElements.java
@@ -112,8 +112,11 @@ public class TurbineElements implements Elements {
   }
 
   @Override
-  public Name getBinaryName(TypeElement type) {
-    throw new UnsupportedOperationException();
+  public Name getBinaryName(TypeElement element) {
+    if (!(element instanceof TurbineTypeElement)) {
+      throw new IllegalArgumentException(element.toString());
+    }
+    return getName(((TurbineTypeElement) element).sym().binaryName().replace('/', '.'));
   }
 
   /**

--- a/java/com/google/turbine/processing/TurbineElements.java
+++ b/java/com/google/turbine/processing/TurbineElements.java
@@ -296,6 +296,12 @@ public class TurbineElements implements Elements {
       // https://bugs.openjdk.java.net/browse/JDK-8227617
       return String.format("(short)%d", (Short) value);
     }
+    if (value instanceof String) {
+      return new Const.StringValue((String) value).toString();
+    }
+    if (value instanceof Character) {
+      return new Const.CharValue((Character) value).toString();
+    }
     return String.valueOf(value);
   }
 

--- a/java/com/google/turbine/processing/TurbineElements.java
+++ b/java/com/google/turbine/processing/TurbineElements.java
@@ -80,7 +80,7 @@ public class TurbineElements implements Elements {
   @Override
   public Map<? extends ExecutableElement, ? extends AnnotationValue> getElementValuesWithDefaults(
       AnnotationMirror a) {
-    throw new UnsupportedOperationException();
+    return ((TurbineAnnotationMirror) a).getElementValuesWithDefaults();
   }
 
   @Override

--- a/java/com/google/turbine/processing/TurbineElements.java
+++ b/java/com/google/turbine/processing/TurbineElements.java
@@ -28,6 +28,7 @@ import com.google.turbine.binder.sym.PackageSymbol;
 import com.google.turbine.binder.sym.ParamSymbol;
 import com.google.turbine.binder.sym.Symbol;
 import com.google.turbine.binder.sym.TyVarSymbol;
+import com.google.turbine.model.Const;
 import com.google.turbine.model.TurbineVisibility;
 import com.google.turbine.processing.TurbineElement.TurbineExecutableElement;
 import com.google.turbine.processing.TurbineElement.TurbineFieldElement;
@@ -278,7 +279,24 @@ public class TurbineElements implements Elements {
 
   @Override
   public String getConstantExpression(Object value) {
-    throw new UnsupportedOperationException();
+    if (value instanceof Byte) {
+      return new Const.ByteValue((Byte) value).toString();
+    }
+    if (value instanceof Long) {
+      return new Const.LongValue((Long) value).toString();
+    }
+    if (value instanceof Float) {
+      return new Const.FloatValue((Float) value).toString();
+    }
+    if (value instanceof Double) {
+      return new Const.DoubleValue((Double) value).toString();
+    }
+    if (value instanceof Short) {
+      // Special-case short for consistency with javac, see:
+      // https://bugs.openjdk.java.net/browse/JDK-8227617
+      return String.format("(short)%d", (Short) value);
+    }
+    return String.valueOf(value);
   }
 
   @Override

--- a/java/com/google/turbine/processing/TurbineElements.java
+++ b/java/com/google/turbine/processing/TurbineElements.java
@@ -32,7 +32,9 @@ import com.google.turbine.model.Const;
 import com.google.turbine.model.TurbineVisibility;
 import com.google.turbine.processing.TurbineElement.TurbineExecutableElement;
 import com.google.turbine.processing.TurbineElement.TurbineFieldElement;
+import com.google.turbine.processing.TurbineElement.TurbineTypeElement;
 import com.google.turbine.processing.TurbineTypeMirror.TurbineExecutableType;
+import com.google.turbine.type.AnnoInfo;
 import java.io.Writer;
 import java.util.HashSet;
 import java.util.List;
@@ -97,8 +99,16 @@ public class TurbineElements implements Elements {
   }
 
   @Override
-  public boolean isDeprecated(Element e) {
-    throw new UnsupportedOperationException();
+  public boolean isDeprecated(Element element) {
+    if (!(element instanceof TurbineElement)) {
+      throw new IllegalArgumentException(element.toString());
+    }
+    for (AnnoInfo a : ((TurbineTypeElement) element).annos()) {
+      if (a.sym().equals(ClassSymbol.DEPRECATED)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override

--- a/java/com/google/turbine/processing/TurbineFiler.java
+++ b/java/com/google/turbine/processing/TurbineFiler.java
@@ -120,7 +120,7 @@ public class TurbineFiler implements Filer {
         case OTHER:
           generatedResources.put(path, e.bytes());
           break;
-        default:
+        case HTML:
           throw new UnsupportedOperationException(String.valueOf(e.getKind()));
       }
     }
@@ -203,7 +203,7 @@ public class TurbineFiler implements Filer {
     }
   }
 
-  private String packageRelativePath(String pkg, String relativeName) {
+  private static String packageRelativePath(String pkg, String relativeName) {
     if (pkg.isEmpty()) {
       return relativeName;
     }
@@ -351,7 +351,7 @@ public class TurbineFiler implements Filer {
       try {
         return loader.getResource(path).toURI();
       } catch (URISyntaxException e) {
-        throw new UnsupportedOperationException(e);
+        throw new AssertionError(e);
       }
     }
 

--- a/java/com/google/turbine/processing/TurbineFiler.java
+++ b/java/com/google/turbine/processing/TurbineFiler.java
@@ -1,0 +1,423 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.common.base.Function;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.ByteStreams;
+import com.google.turbine.diag.SourceFile;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.Writer;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.FilerException;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.NestingKind;
+import javax.tools.FileObject;
+import javax.tools.JavaFileManager.Location;
+import javax.tools.JavaFileObject;
+import javax.tools.JavaFileObject.Kind;
+import javax.tools.StandardLocation;
+
+/** Turbine's implementation of {@link Filer}. */
+public class TurbineFiler implements Filer {
+
+  /**
+   * Existing paths of file objects that cannot be regenerated, including the original compilation
+   * inputs and source or class files generated during any annotation processing round.
+   */
+  private final Set<String> seen;
+
+  /**
+   * File objects generated during the current processing round. Each entry has a unique path, which
+   * is enforced by {@link #seen}.
+   */
+  private final List<TurbineJavaFileObject> files = new ArrayList<>();
+
+  /** Loads resources from the classpath. */
+  private final Function<String, Supplier<byte[]>> classPath;
+
+  /** The {@link ClassLoader} for the annotation processor path, for loading resources. */
+  private final ClassLoader loader;
+
+  private final Map<String, SourceFile> generatedSources = new LinkedHashMap<>();
+  private final Map<String, byte[]> generatedClasses = new LinkedHashMap<>();
+  private final Map<String, byte[]> generatedResources = new LinkedHashMap<>();
+
+  /** Generated source file objects from all rounds. */
+  public ImmutableList<SourceFile> generatedSources() {
+    return ImmutableList.copyOf(generatedSources.values());
+  }
+
+  /** Generated class file objects from all rounds. */
+  public ImmutableMap<String, byte[]> generatedClasses() {
+    return ImmutableMap.copyOf(generatedClasses);
+  }
+
+  /** Generated resource file objects from all rounds. */
+  public ImmutableMap<String, byte[]> generatedResources() {
+    return ImmutableMap.copyOf(generatedResources);
+  }
+
+  TurbineFiler(Set<String> seen, Function<String, Supplier<byte[]>> classPath, ClassLoader loader) {
+    this.seen = seen;
+    this.classPath = classPath;
+    this.loader = loader;
+  }
+
+  /**
+   * Called when the current annotation processing round is complete, and returns the sources
+   * generated in that round.
+   */
+  public Collection<SourceFile> finishRound() {
+    Map<String, SourceFile> roundSources = new LinkedHashMap<>();
+    for (TurbineJavaFileObject e : files) {
+      String path = e.getName();
+      switch (e.getKind()) {
+        case SOURCE:
+          roundSources.put(path, new SourceFile(path, e.contents()));
+          break;
+        case CLASS:
+          generatedClasses.put(path, e.bytes());
+          break;
+        case OTHER:
+          generatedResources.put(path, e.bytes());
+          break;
+        default:
+          throw new UnsupportedOperationException(String.valueOf(e.getKind()));
+      }
+    }
+    files.clear();
+    this.generatedSources.putAll(roundSources);
+    return roundSources.values();
+  }
+
+  @Override
+  public JavaFileObject createSourceFile(CharSequence n, Element... originatingElements)
+      throws IOException {
+    String name = n.toString();
+    checkArgument(!name.contains("/"), "invalid type name: %s", name);
+    return create(Kind.SOURCE, name.replace('.', '/') + ".java");
+  }
+
+  @Override
+  public JavaFileObject createClassFile(CharSequence n, Element... originatingElements)
+      throws IOException {
+    String name = n.toString();
+    checkArgument(!name.contains("/"), "invalid type name: %s", name);
+    return create(Kind.CLASS, name.replace('.', '/') + ".class");
+  }
+
+  @Override
+  public FileObject createResource(
+      Location location, CharSequence p, CharSequence r, Element... originatingElements)
+      throws IOException {
+    String pkg = p.toString();
+    String relativeName = r.toString();
+    checkArgument(!pkg.contains("/"), "invalid package: %s", pkg);
+    String path = packageRelativePath(pkg, relativeName);
+    return create(Kind.OTHER, path);
+  }
+
+  private JavaFileObject create(Kind kind, String path) throws FilerException {
+    if (!seen.add(path)) {
+      throw new FilerException("already created " + path);
+    }
+    TurbineJavaFileObject result = new TurbineJavaFileObject(kind, path);
+    files.add(result);
+    return result;
+  }
+
+  @Override
+  public FileObject getResource(Location location, CharSequence p, CharSequence r)
+      throws IOException {
+    String pkg = p.toString();
+    String relativeName = r.toString();
+    checkArgument(!pkg.contains("/"), "invalid package: %s", pkg);
+    checkArgument(location instanceof StandardLocation, "unsupported location %s", location);
+    StandardLocation standardLocation = (StandardLocation) location;
+    String path = packageRelativePath(pkg, relativeName);
+    switch (standardLocation) {
+      case CLASS_OUTPUT:
+        byte[] generated = generatedClasses.get(path);
+        if (generated == null) {
+          throw new FileNotFoundException(path);
+        }
+        return new BytesFileObject(path, Suppliers.ofInstance(generated));
+      case SOURCE_OUTPUT:
+        SourceFile source = generatedSources.get(path);
+        if (source == null) {
+          throw new FileNotFoundException(path);
+        }
+        return new SourceFileObject(path, source.source());
+      case ANNOTATION_PROCESSOR_PATH:
+        if (loader.getResource(path) == null) {
+          throw new FileNotFoundException(path);
+        }
+        return new ResourceFileObject(loader, path);
+      case CLASS_PATH:
+        Supplier<byte[]> bytes = classPath.apply(path);
+        if (bytes == null) {
+          throw new FileNotFoundException(path);
+        }
+        return new BytesFileObject(path, bytes);
+      default:
+        throw new IllegalArgumentException(standardLocation.getName());
+    }
+  }
+
+  private String packageRelativePath(String pkg, String relativeName) {
+    if (pkg.isEmpty()) {
+      return relativeName;
+    }
+    return pkg.replace('.', '/') + '/' + relativeName;
+  }
+
+  private abstract static class ReadOnlyFileObject implements FileObject {
+
+    protected final String path;
+
+    public ReadOnlyFileObject(String path) {
+      this.path = path;
+    }
+
+    @Override
+    public final String getName() {
+      return path;
+    }
+
+    @Override
+    public URI toUri() {
+      return URI.create("file://" + path);
+    }
+
+    @Override
+    public final OutputStream openOutputStream() {
+      throw new IllegalStateException();
+    }
+
+    @Override
+    public final Writer openWriter() {
+      throw new IllegalStateException();
+    }
+
+    @Override
+    public final long getLastModified() {
+      return 0;
+    }
+
+    @Override
+    public final boolean delete() {
+      throw new IllegalStateException();
+    }
+  }
+
+  private abstract static class WriteOnlyFileObject implements FileObject {
+
+    @Override
+    public final InputStream openInputStream() {
+      throw new IllegalStateException();
+    }
+
+    @Override
+    public final Reader openReader(boolean ignoreEncodingErrors) {
+      throw new IllegalStateException();
+    }
+
+    @Override
+    public final CharSequence getCharContent(boolean ignoreEncodingErrors) {
+      throw new IllegalStateException();
+    }
+  }
+
+  private static class TurbineJavaFileObject extends WriteOnlyFileObject implements JavaFileObject {
+
+    private final Kind kind;
+    private final CharSequence name;
+    private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+    public TurbineJavaFileObject(Kind kind, CharSequence name) {
+      this.kind = kind;
+      this.name = name;
+    }
+
+    @Override
+    public Kind getKind() {
+      return kind;
+    }
+
+    @Override
+    public boolean isNameCompatible(String simpleName, Kind kind) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public NestingKind getNestingKind() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Modifier getAccessLevel() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public URI toUri() {
+      return URI.create("file://" + name + kind.extension);
+    }
+
+    @Override
+    public String getName() {
+      return name.toString();
+    }
+
+    @Override
+    public OutputStream openOutputStream() {
+      return baos;
+    }
+
+    @Override
+    public Writer openWriter() {
+      return new OutputStreamWriter(openOutputStream(), UTF_8);
+    }
+
+    @Override
+    public long getLastModified() {
+      return 0;
+    }
+
+    @Override
+    public boolean delete() {
+      throw new IllegalStateException();
+    }
+
+    public byte[] bytes() {
+      return baos.toByteArray();
+    }
+
+    public String contents() {
+      return new String(baos.toByteArray(), UTF_8);
+    }
+  }
+
+  private static class ResourceFileObject extends ReadOnlyFileObject {
+
+    private final ClassLoader loader;
+
+    public ResourceFileObject(ClassLoader loader, String path) {
+      super(path);
+      this.loader = loader;
+    }
+
+    @Override
+    public URI toUri() {
+      try {
+        return loader.getResource(path).toURI();
+      } catch (URISyntaxException e) {
+        throw new UnsupportedOperationException(e);
+      }
+    }
+
+    @Override
+    public InputStream openInputStream() {
+      return loader.getResourceAsStream(path);
+    }
+
+    @Override
+    public Reader openReader(boolean ignoreEncodingErrors) throws IOException {
+      return new InputStreamReader(openInputStream(), UTF_8);
+    }
+
+    @Override
+    public CharSequence getCharContent(boolean ignoreEncodingErrors) throws IOException {
+      return new String(ByteStreams.toByteArray(openInputStream()), UTF_8);
+    }
+  }
+
+  private static class BytesFileObject extends ReadOnlyFileObject {
+
+    private final Supplier<byte[]> bytes;
+
+    public BytesFileObject(String path, Supplier<byte[]> bytes) {
+      super(path);
+      this.bytes = bytes;
+    }
+
+    @Override
+    public InputStream openInputStream() {
+      return new ByteArrayInputStream(bytes.get());
+    }
+
+    @Override
+    public Reader openReader(boolean ignoreEncodingErrors) {
+      return new InputStreamReader(openInputStream(), UTF_8);
+    }
+
+    @Override
+    public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+      return new String(bytes.get(), UTF_8);
+    }
+  }
+
+  private static class SourceFileObject extends ReadOnlyFileObject {
+
+    private final String source;
+
+    public SourceFileObject(String path, String source) {
+      super(path);
+      this.source = source;
+    }
+
+    @Override
+    public InputStream openInputStream() {
+      return new ByteArrayInputStream(source.getBytes(UTF_8));
+    }
+
+    @Override
+    public Reader openReader(boolean ignoreEncodingErrors) {
+      return new StringReader(source);
+    }
+
+    @Override
+    public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+      return source;
+    }
+  }
+}

--- a/java/com/google/turbine/processing/TurbineName.java
+++ b/java/com/google/turbine/processing/TurbineName.java
@@ -23,16 +23,16 @@ import javax.lang.model.element.Name;
 /** An implementation of {@link Name} backed by a {@link CharSequence}. */
 public class TurbineName implements Name {
 
-  private final CharSequence name;
+  private final String name;
 
-  public TurbineName(CharSequence name) {
+  public TurbineName(String name) {
     requireNonNull(name);
     this.name = name;
   }
 
   @Override
   public boolean contentEquals(CharSequence cs) {
-    return name.toString().contentEquals(cs);
+    return name.contentEquals(cs);
   }
 
   @Override
@@ -52,7 +52,7 @@ public class TurbineName implements Name {
 
   @Override
   public String toString() {
-    return name.toString();
+    return name;
   }
 
   @Override

--- a/java/com/google/turbine/processing/TurbineTypeMirror.java
+++ b/java/com/google/turbine/processing/TurbineTypeMirror.java
@@ -252,7 +252,7 @@ public abstract class TurbineTypeMirror implements TypeMirror {
 
     @Override
     protected ImmutableList<AnnoInfo> annos() {
-      return ImmutableList.of();
+      return getLast(type.classes()).annos();
     }
   }
 

--- a/java/com/google/turbine/processing/TurbineTypeMirror.java
+++ b/java/com/google/turbine/processing/TurbineTypeMirror.java
@@ -330,7 +330,7 @@ public abstract class TurbineTypeMirror implements TypeMirror {
 
     @Override
     public int hashCode() {
-      return getKind().hashCode();
+      return symbol.hashCode();
     }
 
     @Override

--- a/java/com/google/turbine/processing/TurbineTypeMirror.java
+++ b/java/com/google/turbine/processing/TurbineTypeMirror.java
@@ -578,14 +578,7 @@ public abstract class TurbineTypeMirror implements TypeMirror {
             new Supplier<ImmutableList<TypeMirror>>() {
               @Override
               public ImmutableList<TypeMirror> get() {
-                ImmutableList.Builder<TypeMirror> result = ImmutableList.builder();
-                ImmutableList<Type> bounds = type.bounds();
-                if (factory.getSymbol(((ClassTy) bounds.get(0)).sym()).kind()
-                    == TurbineTyKind.INTERFACE) {
-                  result.add(factory.asTypeMirror(ClassTy.OBJECT));
-                }
-                result.addAll(factory.asTypeMirrors(bounds));
-                return result.build();
+                return factory.asTypeMirrors(TurbineTypes.getBounds(factory, type));
               }
             });
 

--- a/java/com/google/turbine/processing/TurbineTypeMirror.java
+++ b/java/com/google/turbine/processing/TurbineTypeMirror.java
@@ -30,6 +30,7 @@ import com.google.turbine.binder.sym.TyVarSymbol;
 import com.google.turbine.model.TurbineConstantTypeKind;
 import com.google.turbine.model.TurbineFlag;
 import com.google.turbine.model.TurbineTyKind;
+import com.google.turbine.type.AnnoInfo;
 import com.google.turbine.type.Type;
 import com.google.turbine.type.Type.ArrayTy;
 import com.google.turbine.type.Type.ClassTy;
@@ -64,9 +65,15 @@ public abstract class TurbineTypeMirror implements TypeMirror {
     this.factory = requireNonNull(factory);
   }
 
+  protected abstract ImmutableList<AnnoInfo> annos();
+
   @Override
   public final List<? extends AnnotationMirror> getAnnotationMirrors() {
-    throw new UnsupportedOperationException();
+    ImmutableList.Builder<AnnotationMirror> result = ImmutableList.builder();
+    for (AnnoInfo anno : annos()) {
+      result.add(TurbineAnnotationMirror.create(factory, anno));
+    }
+    return result.build();
   }
 
   @Override
@@ -138,6 +145,11 @@ public abstract class TurbineTypeMirror implements TypeMirror {
     @Override
     public <R, P> R accept(TypeVisitor<R, P> v, P p) {
       return v.visitPrimitive(this, p);
+    }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return type.annos();
     }
   }
 
@@ -237,6 +249,11 @@ public abstract class TurbineTypeMirror implements TypeMirror {
     public ClassTy type() {
       return type;
     }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return ImmutableList.of();
+    }
   }
 
   /** An {@link ArrayType} implementation backed by a {@link ArrayTy}. */
@@ -267,6 +284,11 @@ public abstract class TurbineTypeMirror implements TypeMirror {
     @Override
     public <R, P> R accept(TypeVisitor<R, P> v, P p) {
       return v.visitArray(this, p);
+    }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return type.annos();
     }
   }
 
@@ -310,6 +332,11 @@ public abstract class TurbineTypeMirror implements TypeMirror {
     public int hashCode() {
       return getKind().hashCode();
     }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return ImmutableList.of();
+    }
   }
 
   /** The absence of a type, {@see javax.lang.model.util.Types#getNoType}. */
@@ -348,6 +375,11 @@ public abstract class TurbineTypeMirror implements TypeMirror {
     public int hashCode() {
       return getKind().hashCode();
     }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return ImmutableList.of();
+    }
   }
 
   /** A void type, {@see javax.lang.model.util.Types#getNoType}. */
@@ -370,6 +402,11 @@ public abstract class TurbineTypeMirror implements TypeMirror {
     @Override
     public <R, P> R accept(TypeVisitor<R, P> v, P p) {
       return v.visitNoType(this, p);
+    }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return ImmutableList.of();
     }
   }
 
@@ -442,6 +479,11 @@ public abstract class TurbineTypeMirror implements TypeMirror {
     public String toString() {
       return type.toString();
     }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return type.annos();
+    }
   }
 
   /** A {@link WildcardType} implementation backed by a {@link WildTy}. */
@@ -487,6 +529,11 @@ public abstract class TurbineTypeMirror implements TypeMirror {
     @Override
     public TypeMirror getSuperBound() {
       return type.boundKind() == BoundKind.LOWER ? factory.asTypeMirror(type.bound()) : null;
+    }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return type.annotations();
     }
   }
 
@@ -550,6 +597,11 @@ public abstract class TurbineTypeMirror implements TypeMirror {
     @Override
     public String toString() {
       return Joiner.on('&').join(getBounds());
+    }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return ImmutableList.of();
     }
   }
 
@@ -623,6 +675,11 @@ public abstract class TurbineTypeMirror implements TypeMirror {
     @Override
     public <R, P> R accept(TypeVisitor<R, P> v, P p) {
       return v.visitExecutable(this, p);
+    }
+
+    @Override
+    protected ImmutableList<AnnoInfo> annos() {
+      return ImmutableList.of();
     }
   }
 }

--- a/java/com/google/turbine/type/Type.java
+++ b/java/com/google/turbine/type/Type.java
@@ -27,7 +27,10 @@ import com.google.common.collect.Iterables;
 import com.google.turbine.binder.sym.ClassSymbol;
 import com.google.turbine.binder.sym.TyVarSymbol;
 import com.google.turbine.model.TurbineConstantTypeKind;
+import com.google.turbine.tree.Tree;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** JLS 4 types. */
@@ -528,13 +531,28 @@ public interface Type {
   /** An error type. */
   @AutoValue
   abstract class ErrorTy implements Type {
-    public static ErrorTy create() {
-      return new AutoValue_Type_ErrorTy();
+    abstract String name();
+
+    public static ErrorTy create(Iterable<Tree.Ident> names) {
+      List<String> bits = new ArrayList<>();
+      for (Tree.Ident ident : names) {
+        bits.add(ident.value());
+      }
+      return create(Joiner.on('.').join(bits));
+    }
+
+    public static ErrorTy create(String name) {
+      return new AutoValue_Type_ErrorTy(name);
     }
 
     @Override
     public TyKind tyKind() {
       return TyKind.ERROR_TY;
+    }
+
+    @Override
+    public final String toString() {
+      return name();
     }
   }
 }

--- a/java/com/google/turbine/type/Type.java
+++ b/java/com/google/turbine/type/Type.java
@@ -110,6 +110,9 @@ public interface Type {
     /** The {@link ClassTy} for {@code java.lang.String}. */
     public static final ClassTy STRING = asNonParametricClassTy(ClassSymbol.STRING);
 
+    public static final ClassTy CLONEABLE = asNonParametricClassTy(ClassSymbol.CLONEABLE);
+    public static final ClassTy SERIALIZABLE = asNonParametricClassTy(ClassSymbol.SERIALIZABLE);
+
     /** Returns a {@link ClassTy} with no type arguments for the given {@link ClassSymbol}. */
     public static ClassTy asNonParametricClassTy(ClassSymbol i) {
       return ClassTy.create(

--- a/java/com/google/turbine/types/Erasure.java
+++ b/java/com/google/turbine/types/Erasure.java
@@ -67,7 +67,7 @@ public class Erasure {
 
   private static Type eraseIntersectionTy(
       IntersectionTy ty, Function<TyVarSymbol, TyVarInfo> tenv) {
-    return erase(ty.bounds().get(0), tenv);
+    return ty.bounds().isEmpty() ? ClassTy.OBJECT : erase(ty.bounds().get(0), tenv);
   }
 
   private static Type eraseTyVar(

--- a/javatests/com/google/turbine/binder/BinderErrorTest.java
+++ b/javatests/com/google/turbine/binder/BinderErrorTest.java
@@ -568,7 +568,26 @@ public class BinderErrorTest {
           "@One.A(b = {@One.NoSuch})",
           "                 ^",
         },
-      }
+      },
+      {
+        {
+          "public class Test {", //
+          "  @interface Anno {",
+          "    Class<?> value() default Object.class;",
+          "  }",
+          "  @Anno(NoSuch.class) int x;",
+          "  @Anno(NoSuch.class) int y;",
+          "}",
+        },
+        {
+          "<>:5: error: could not resolve NoSuch",
+          "  @Anno(NoSuch.class) int x;",
+          "        ^",
+          "<>:6: error: could not resolve NoSuch",
+          "  @Anno(NoSuch.class) int y;",
+          "        ^",
+        },
+      },
     };
     return Arrays.asList((Object[][]) testCases);
   }

--- a/javatests/com/google/turbine/binder/bytecode/BytecodeBoundClassTest.java
+++ b/javatests/com/google/turbine/binder/bytecode/BytecodeBoundClassTest.java
@@ -86,6 +86,10 @@ public class BytecodeBoundClassTest {
     <X, Y extends X, Z extends Throwable> X foo(@Deprecated X bar, Y baz) throws IOException, Z {
       return null;
     }
+
+    void baz() throws IOException {
+      throw new IOException();
+    }
   }
 
   @Test
@@ -99,6 +103,12 @@ public class BytecodeBoundClassTest {
     assertThat(m.parameters().get(0).annotations()).hasSize(1);
     assertThat(m.parameters().get(0).name()).isEqualTo("bar");
     assertThat(m.exceptions()).hasSize(2);
+
+    MethodInfo b =
+        getBytecodeBoundClass(HasMethod.class).methods().stream()
+            .filter(x -> x.name().equals("baz"))
+            .collect(onlyElement());
+    assertThat(b.exceptions()).hasSize(1);
   }
 
   @interface VoidAnno {

--- a/javatests/com/google/turbine/lower/IntegrationTestSupport.java
+++ b/javatests/com/google/turbine/lower/IntegrationTestSupport.java
@@ -101,8 +101,11 @@ public class IntegrationTestSupport {
   public static Map<String, byte[]> canonicalize(Map<String, byte[]> in) {
     List<ClassNode> classes = toClassNodes(in);
 
-    // drop anonymous classes
-    classes = classes.stream().filter(n -> !isAnonymous(n)).collect(toCollection(ArrayList::new));
+    // drop local and anonymous classes
+    classes =
+        classes.stream()
+            .filter(n -> !isAnonymous(n) && !isLocal(n))
+            .collect(toCollection(ArrayList::new));
 
     // collect all inner classes attributes
     Map<String, InnerClassNode> infos = new HashMap<>();
@@ -122,6 +125,10 @@ public class IntegrationTestSupport {
     }
 
     return toByteCode(classes);
+  }
+
+  private static boolean isLocal(ClassNode n) {
+    return n.outerMethod != null;
   }
 
   private static boolean isAnonymous(ClassNode n) {

--- a/javatests/com/google/turbine/lower/LowerIntegrationTest.java
+++ b/javatests/com/google/turbine/lower/LowerIntegrationTest.java
@@ -310,6 +310,7 @@ public class LowerIntegrationTest {
       "anno_void.test",
       "tyanno_varargs.test",
       "tyanno_inner.test",
+      "local.test",
     };
     List<Object[]> tests =
         ImmutableList.copyOf(testCases).stream().map(x -> new Object[] {x}).collect(toList());

--- a/javatests/com/google/turbine/lower/testdata/local.test
+++ b/javatests/com/google/turbine/lower/testdata/local.test
@@ -1,0 +1,8 @@
+=== T.java ===
+class T {
+  Object f() {
+    class Local {
+    }
+    return new Local();
+  }
+}

--- a/javatests/com/google/turbine/model/ConstTest.java
+++ b/javatests/com/google/turbine/model/ConstTest.java
@@ -131,7 +131,7 @@ public class ConstTest {
         .isEqualTo("@p.Anno(x=1, y=2)");
     assertThat(new Const.StringValue("\"").toString()).isEqualTo("\"\\\"\"");
     assertThat(new Const.ByteValue((byte) 42).toString()).isEqualTo("(byte)0x2a");
-    assertThat(new Const.ShortValue((short) 42).toString()).isEqualTo("(short)42");
+    assertThat(new Const.ShortValue((short) 42).toString()).isEqualTo("42");
   }
 
   private static String makeAnno(ImmutableMap<String, Const> value) {

--- a/javatests/com/google/turbine/parse/ParseErrorTest.java
+++ b/javatests/com/google/turbine/parse/ParseErrorTest.java
@@ -228,6 +228,23 @@ public class ParseErrorTest {
     }
   }
 
+  @Test
+  public void abruptMultivariableDeclaration() {
+    String input = "class T { int x,; }";
+    try {
+      Parser.parse(input);
+      fail("expected parsing to fail");
+    } catch (TurbineError e) {
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo(
+              lines(
+                  "<>:1: error: expected token <identifier>", //
+                  "class T { int x,; }",
+                  "                ^"));
+    }
+  }
+
   private static String lines(String... lines) {
     return Joiner.on(System.lineSeparator()).join(lines);
   }

--- a/javatests/com/google/turbine/processing/AbstractTurbineTypesTest.java
+++ b/javatests/com/google/turbine/processing/AbstractTurbineTypesTest.java
@@ -371,7 +371,7 @@ class AbstractTurbineTypesTest {
     Env<ClassSymbol, TypeBoundClass> env =
         CompoundEnv.<ClassSymbol, TypeBoundClass>of(bound.classPathEnv())
             .append(new SimpleEnv<>(bound.units()));
-    ModelFactory factory = new ModelFactory(env, ClassLoader.getSystemClassLoader());
+    ModelFactory factory = new ModelFactory(env, ClassLoader.getSystemClassLoader(), bound.tli());
     Types turbineTypes = new TurbineTypes(factory);
     ImmutableMap<String, Element> turbineElements =
         bound.units().keySet().stream()

--- a/javatests/com/google/turbine/processing/AbstractTurbineTypesTest.java
+++ b/javatests/com/google/turbine/processing/AbstractTurbineTypesTest.java
@@ -371,7 +371,7 @@ class AbstractTurbineTypesTest {
     Env<ClassSymbol, TypeBoundClass> env =
         CompoundEnv.<ClassSymbol, TypeBoundClass>of(bound.classPathEnv())
             .append(new SimpleEnv<>(bound.units()));
-    ModelFactory factory = new ModelFactory(env);
+    ModelFactory factory = new ModelFactory(env, ClassLoader.getSystemClassLoader());
     Types turbineTypes = new TurbineTypes(factory);
     ImmutableMap<String, Element> turbineElements =
         bound.units().keySet().stream()

--- a/javatests/com/google/turbine/processing/TurbineAnnotationMirrorTest.java
+++ b/javatests/com/google/turbine/processing/TurbineAnnotationMirrorTest.java
@@ -197,7 +197,7 @@ public class TurbineAnnotationMirrorTest {
     Env<ClassSymbol, TypeBoundClass> env =
         CompoundEnv.<ClassSymbol, TypeBoundClass>of(bound.classPathEnv())
             .append(new SimpleEnv<>(bound.units()));
-    ModelFactory factory = new ModelFactory(env, ClassLoader.getSystemClassLoader());
+    ModelFactory factory = new ModelFactory(env, ClassLoader.getSystemClassLoader(), bound.tli());
     TurbineTypes turbineTypes = new TurbineTypes(factory);
     TurbineElements turbineElements = new TurbineElements(factory, turbineTypes);
 

--- a/javatests/com/google/turbine/processing/TurbineAnnotationMirrorTest.java
+++ b/javatests/com/google/turbine/processing/TurbineAnnotationMirrorTest.java
@@ -197,7 +197,7 @@ public class TurbineAnnotationMirrorTest {
     Env<ClassSymbol, TypeBoundClass> env =
         CompoundEnv.<ClassSymbol, TypeBoundClass>of(bound.classPathEnv())
             .append(new SimpleEnv<>(bound.units()));
-    ModelFactory factory = new ModelFactory(env);
+    ModelFactory factory = new ModelFactory(env, ClassLoader.getSystemClassLoader());
     TurbineTypes turbineTypes = new TurbineTypes(factory);
     TurbineElements turbineElements = new TurbineElements(factory, turbineTypes);
 

--- a/javatests/com/google/turbine/processing/TurbineAnnotationMirrorTest.java
+++ b/javatests/com/google/turbine/processing/TurbineAnnotationMirrorTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.stream.Collectors.toList;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.turbine.binder.Binder;
+import com.google.turbine.binder.ClassPathBinder;
+import com.google.turbine.binder.bound.TypeBoundClass;
+import com.google.turbine.binder.env.CompoundEnv;
+import com.google.turbine.binder.env.Env;
+import com.google.turbine.binder.env.SimpleEnv;
+import com.google.turbine.binder.sym.ClassSymbol;
+import com.google.turbine.diag.SourceFile;
+import com.google.turbine.lower.IntegrationTestSupport.TestInput;
+import com.google.turbine.parse.Parser;
+import com.google.turbine.processing.TurbineElement.TurbineTypeElement;
+import com.google.turbine.testing.TestClassPaths;
+import com.google.turbine.tree.Tree.CompUnit;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.AbstractAnnotationValueVisitor8;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TurbineAnnotationMirrorTest {
+
+  private AnnotationMirror getAnnotation(
+      List<? extends AnnotationMirror> annotationMirrors, String name) {
+    return annotationMirrors.stream()
+        .filter(x -> x.getAnnotationType().asElement().getSimpleName().contentEquals(name))
+        .findFirst()
+        .get();
+  }
+
+  private ImmutableMap<String, Object> values(AnnotationMirror a) {
+    return values(a.getElementValues());
+  }
+
+  /**
+   * Returns a map from the name of annotation elements to their values, see also {@link
+   * #getValue(AnnotationValue)}.
+   */
+  private ImmutableMap<String, Object> values(
+      Map<? extends ExecutableElement, ? extends AnnotationValue> values) {
+    return values.entrySet().stream()
+        .collect(
+            toImmutableMap(
+                e -> e.getKey().getSimpleName().toString(), e -> getValue(e.getValue())));
+  }
+
+  /**
+   * Returns the given annotation value as an Object (for primitives), or a list (for arrays), or
+   * strings (for compound annotations, enums, and class literals).
+   */
+  static Object getValue(AnnotationValue value) {
+    return value.accept(
+        new AbstractAnnotationValueVisitor8<Object, Void>() {
+          @Override
+          public Object visitBoolean(boolean b, Void unused) {
+            return b;
+          }
+
+          @Override
+          public Object visitByte(byte b, Void unused) {
+            return b;
+          }
+
+          @Override
+          public Object visitChar(char c, Void unused) {
+            return c;
+          }
+
+          @Override
+          public Object visitDouble(double d, Void unused) {
+            return d;
+          }
+
+          @Override
+          public Object visitFloat(float f, Void unused) {
+            return f;
+          }
+
+          @Override
+          public Object visitInt(int i, Void unused) {
+            return i;
+          }
+
+          @Override
+          public Object visitLong(long i, Void unused) {
+            return i;
+          }
+
+          @Override
+          public Object visitShort(short s, Void unused) {
+            return s;
+          }
+
+          @Override
+          public Object visitString(String s, Void unused) {
+            return s;
+          }
+
+          @Override
+          public Object visitType(TypeMirror t, Void unused) {
+            return value.toString();
+          }
+
+          @Override
+          public Object visitEnumConstant(VariableElement c, Void unused) {
+            return value.toString();
+          }
+
+          @Override
+          public Object visitAnnotation(AnnotationMirror a, Void unused) {
+            return value.toString();
+          }
+
+          @Override
+          public Object visitArray(List<? extends AnnotationValue> vals, Void unused) {
+            return vals.stream().map(v -> v.accept(this, null)).collect(toImmutableList());
+          }
+        },
+        null);
+  }
+
+  @Test
+  public void test() throws IOException {
+    TestInput input =
+        TestInput.parse(
+            Joiner.on('\n')
+                .join(
+                    "=== Test.java ===",
+                    "import java.lang.annotation.ElementType;",
+                    "import java.lang.annotation.Retention;",
+                    "import java.lang.annotation.RetentionPolicy;",
+                    "import java.lang.annotation.Target;",
+                    "@Retention(RetentionPolicy.RUNTIME)",
+                    "@interface A {",
+                    "  int x() default 0;",
+                    "  int y() default 1;",
+                    "  int[] z() default {};",
+                    "}",
+                    "@interface B {",
+                    "  Class<?> c() default String.class;",
+                    "  ElementType e() default ElementType.TYPE_USE;",
+                    "  A f() default @A;",
+                    "}",
+                    "@A(y = 42, z = {43})",
+                    "@B",
+                    "class Test {}",
+                    ""));
+
+    List<CompUnit> units =
+        input.sources.entrySet().stream()
+            .map(e -> new SourceFile(e.getKey(), e.getValue()))
+            .map(Parser::parse)
+            .collect(toList());
+
+    Binder.BindingResult bound =
+        Binder.bind(
+            units,
+            ClassPathBinder.bindClasspath(ImmutableList.of()),
+            TestClassPaths.TURBINE_BOOTCLASSPATH,
+            Optional.empty());
+
+    Env<ClassSymbol, TypeBoundClass> env =
+        CompoundEnv.<ClassSymbol, TypeBoundClass>of(bound.classPathEnv())
+            .append(new SimpleEnv<>(bound.units()));
+    ModelFactory factory = new ModelFactory(env);
+    TurbineTypes turbineTypes = new TurbineTypes(factory);
+    TurbineElements turbineElements = new TurbineElements(factory, turbineTypes);
+
+    TurbineTypeElement te = factory.typeElement(new ClassSymbol("Test"));
+
+    AnnotationMirror a = getAnnotation(te.getAnnotationMirrors(), "A");
+    ((TypeElement) a.getAnnotationType().asElement()).getQualifiedName().contentEquals("A");
+    assertThat(values(a)).containsExactly("y", 42, "z", ImmutableList.of(43));
+    assertThat(values(turbineElements.getElementValuesWithDefaults(a)))
+        .containsExactly(
+            "x", 0,
+            "y", 42,
+            "z", ImmutableList.of(43));
+
+    AnnotationMirror b = getAnnotation(te.getAnnotationMirrors(), "B");
+    assertThat(values(turbineElements.getElementValuesWithDefaults(b)))
+        .containsExactly(
+            "c", "java.lang.String.class",
+            "e", "java.lang.annotation.ElementType.TYPE_USE",
+            "f", "@A");
+  }
+}

--- a/javatests/com/google/turbine/processing/TurbineAnnotationProxyTest.java
+++ b/javatests/com/google/turbine/processing/TurbineAnnotationProxyTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.fail;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.base.StandardSystemProperty;
+import com.google.common.primitives.Ints;
+import com.google.common.testing.EqualsTester;
+import com.google.turbine.binder.Binder;
+import com.google.turbine.binder.ClassPathBinder;
+import com.google.turbine.binder.bound.TypeBoundClass;
+import com.google.turbine.binder.env.CompoundEnv;
+import com.google.turbine.binder.env.Env;
+import com.google.turbine.binder.env.SimpleEnv;
+import com.google.turbine.binder.sym.ClassSymbol;
+import com.google.turbine.diag.SourceFile;
+import com.google.turbine.lower.IntegrationTestSupport.TestInput;
+import com.google.turbine.parse.Parser;
+import com.google.turbine.processing.TurbineElement.TurbineTypeElement;
+import com.google.turbine.testing.TestClassPaths;
+import com.google.turbine.tree.Tree.CompUnit;
+import java.io.File;
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.MirroredTypeException;
+import javax.lang.model.type.MirroredTypesException;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TurbineAnnotationProxyTest {
+
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface A {
+    B b() default @B(-1);
+
+    ElementType e() default ElementType.PACKAGE;
+
+    int[] xs() default {};
+
+    Class<?> c() default String.class;
+
+    Class<?>[] cx() default {};
+  }
+
+  @Retention(RetentionPolicy.RUNTIME)
+  @Inherited
+  public @interface B {
+    int value();
+  }
+
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface C {}
+
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface RS {
+    R[] value() default {};
+  }
+
+  @Repeatable(RS.class)
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface R {
+    int value() default 1;
+  }
+
+  @A
+  static class I {}
+
+  @Test
+  public void test() throws IOException {
+    TestInput input =
+        TestInput.parse(
+            Joiner.on('\n')
+                .join(
+                    "=== Super.java ===",
+                    "import " + B.class.getCanonicalName() + ";",
+                    "import " + C.class.getCanonicalName() + ";",
+                    "@B(42)",
+                    "@C",
+                    "class Super {}",
+                    "=== Test.java ===",
+                    "import " + A.class.getCanonicalName() + ";",
+                    "import " + R.class.getCanonicalName() + ";",
+                    "@A(xs = {1,2,3}, cx = {Integer.class, Long.class})",
+                    "@R(1)",
+                    "@R(2)",
+                    "@R(3)",
+                    "class Test extends Super {}",
+                    ""));
+
+    List<CompUnit> units =
+        input.sources.entrySet().stream()
+            .map(e -> new SourceFile(e.getKey(), e.getValue()))
+            .map(Parser::parse)
+            .collect(toList());
+
+    Binder.BindingResult bound =
+        Binder.bind(
+            units,
+            ClassPathBinder.bindClasspath(
+                Splitter.on(File.pathSeparatorChar)
+                    .splitToList(StandardSystemProperty.JAVA_CLASS_PATH.value())
+                    .stream()
+                    .map(Paths::get)
+                    .collect(toImmutableList())),
+            TestClassPaths.TURBINE_BOOTCLASSPATH,
+            Optional.empty());
+
+    Env<ClassSymbol, TypeBoundClass> env =
+        CompoundEnv.<ClassSymbol, TypeBoundClass>of(bound.classPathEnv())
+            .append(new SimpleEnv<>(bound.units()));
+    ModelFactory factory = new ModelFactory(env, ClassLoader.getSystemClassLoader());
+    TurbineTypeElement te = factory.typeElement(new ClassSymbol("Test"));
+
+    A a = te.getAnnotation(A.class);
+    B b = te.getAnnotation(B.class);
+    assertThat(te.getAnnotation(C.class)).isNull();
+
+    assertThat(a.b().value()).isEqualTo(-1);
+    assertThat(a.e()).isEqualTo(ElementType.PACKAGE);
+    try {
+      a.c();
+      fail();
+    } catch (MirroredTypeException e) {
+      assertThat(e.getTypeMirror().getKind()).isEqualTo(TypeKind.DECLARED);
+      assertThat(getQualifiedName(e.getTypeMirror())).contains("java.lang.String");
+    }
+    try {
+      a.cx();
+      fail();
+    } catch (MirroredTypesException e) {
+      assertThat(
+              e.getTypeMirrors().stream().map(m -> getQualifiedName(m)).collect(toImmutableList()))
+          .containsExactly("java.lang.Integer", "java.lang.Long");
+    }
+    assertThat(Ints.asList(a.xs())).containsExactly(1, 2, 3).inOrder();
+    assertThat(a.annotationType()).isEqualTo(A.class);
+
+    assertThat(b.value()).isEqualTo(42);
+
+    RS container = te.getAnnotation(RS.class);
+    assertThat(container.value()).hasLength(3);
+    R[] rs = te.getAnnotationsByType(R.class);
+    assertThat(rs).hasLength(3);
+    assertThat(Arrays.toString(rs))
+        .isEqualTo(
+            String.format(
+                "[@%s(1), @%s(2), @%s(3)]",
+                R.class.getCanonicalName(),
+                R.class.getCanonicalName(),
+                R.class.getCanonicalName()));
+
+    new EqualsTester()
+        .addEqualityGroup(a, te.getAnnotation(A.class))
+        .addEqualityGroup(b, te.getAnnotation(B.class))
+        .addEqualityGroup(rs[0])
+        .addEqualityGroup(rs[1])
+        .addEqualityGroup(rs[2])
+        .addEqualityGroup(container)
+        .addEqualityGroup(I.class.getAnnotation(A.class))
+        .addEqualityGroup("unrelated")
+        .testEquals();
+  }
+
+  private static String getQualifiedName(TypeMirror typeMirror) {
+    return ((TypeElement) ((DeclaredType) typeMirror).asElement()).getQualifiedName().toString();
+  }
+}

--- a/javatests/com/google/turbine/processing/TurbineAnnotationProxyTest.java
+++ b/javatests/com/google/turbine/processing/TurbineAnnotationProxyTest.java
@@ -142,7 +142,7 @@ public class TurbineAnnotationProxyTest {
     Env<ClassSymbol, TypeBoundClass> env =
         CompoundEnv.<ClassSymbol, TypeBoundClass>of(bound.classPathEnv())
             .append(new SimpleEnv<>(bound.units()));
-    ModelFactory factory = new ModelFactory(env, ClassLoader.getSystemClassLoader());
+    ModelFactory factory = new ModelFactory(env, ClassLoader.getSystemClassLoader(), bound.tli());
     TurbineTypeElement te = factory.typeElement(new ClassSymbol("Test"));
 
     A a = te.getAnnotation(A.class);

--- a/javatests/com/google/turbine/processing/TurbineElementTest.java
+++ b/javatests/com/google/turbine/processing/TurbineElementTest.java
@@ -45,7 +45,9 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class TurbineElementTest {
 
-  private final ModelFactory factory = new ModelFactory(TestClassPaths.TURBINE_BOOTCLASSPATH.env());
+  private final ModelFactory factory =
+      new ModelFactory(
+          TestClassPaths.TURBINE_BOOTCLASSPATH.env(), ClassLoader.getSystemClassLoader());
 
   @Test
   public void typeElement() {

--- a/javatests/com/google/turbine/processing/TurbineElementTest.java
+++ b/javatests/com/google/turbine/processing/TurbineElementTest.java
@@ -47,7 +47,9 @@ public class TurbineElementTest {
 
   private final ModelFactory factory =
       new ModelFactory(
-          TestClassPaths.TURBINE_BOOTCLASSPATH.env(), ClassLoader.getSystemClassLoader());
+          TestClassPaths.TURBINE_BOOTCLASSPATH.env(),
+          ClassLoader.getSystemClassLoader(),
+          TestClassPaths.TURBINE_BOOTCLASSPATH.index());
 
   @Test
   public void typeElement() {

--- a/javatests/com/google/turbine/processing/TurbineElementTest.java
+++ b/javatests/com/google/turbine/processing/TurbineElementTest.java
@@ -84,6 +84,13 @@ public class TurbineElementTest {
                 .getQualifiedName()
                 .toString())
         .isEqualTo("java.util.AbstractMap");
+
+    e = factory.typeElement(new ClassSymbol("java/lang/annotation/ElementType"));
+    assertThat(
+            ((TypeElement) ((DeclaredType) e.getSuperclass()).asElement())
+                .getQualifiedName()
+                .toString())
+        .isEqualTo("java.lang.Enum");
   }
 
   @Test

--- a/javatests/com/google/turbine/processing/TurbineElementsGetAllMembersTest.java
+++ b/javatests/com/google/turbine/processing/TurbineElementsGetAllMembersTest.java
@@ -262,7 +262,7 @@ public class TurbineElementsGetAllMembersTest {
     Env<ClassSymbol, TypeBoundClass> env =
         CompoundEnv.<ClassSymbol, TypeBoundClass>of(bound.classPathEnv())
             .append(new SimpleEnv<>(bound.units()));
-    ModelFactory factory = new ModelFactory(env);
+    ModelFactory factory = new ModelFactory(env, ClassLoader.getSystemClassLoader());
     TurbineTypes turbineTypes = new TurbineTypes(factory);
     TurbineElements turbineElements = new TurbineElements(factory, turbineTypes);
     List<? extends Element> turbineMembers =

--- a/javatests/com/google/turbine/processing/TurbineElementsGetAllMembersTest.java
+++ b/javatests/com/google/turbine/processing/TurbineElementsGetAllMembersTest.java
@@ -262,7 +262,7 @@ public class TurbineElementsGetAllMembersTest {
     Env<ClassSymbol, TypeBoundClass> env =
         CompoundEnv.<ClassSymbol, TypeBoundClass>of(bound.classPathEnv())
             .append(new SimpleEnv<>(bound.units()));
-    ModelFactory factory = new ModelFactory(env, ClassLoader.getSystemClassLoader());
+    ModelFactory factory = new ModelFactory(env, ClassLoader.getSystemClassLoader(), bound.tli());
     TurbineTypes turbineTypes = new TurbineTypes(factory);
     TurbineElements turbineElements = new TurbineElements(factory, turbineTypes);
     List<? extends Element> turbineMembers =

--- a/javatests/com/google/turbine/processing/TurbineElementsTest.java
+++ b/javatests/com/google/turbine/processing/TurbineElementsTest.java
@@ -20,11 +20,13 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.testing.EqualsTester;
 import com.google.turbine.binder.Binder.BindingResult;
 import com.google.turbine.lower.IntegrationTestSupport;
 import com.google.turbine.testing.TestClassPaths;
 import java.util.Arrays;
 import java.util.Optional;
+import javax.lang.model.element.Name;
 import javax.lang.model.util.Elements;
 import org.junit.Before;
 import org.junit.Test;
@@ -89,5 +91,23 @@ public class TurbineElementsTest {
       assertThat(turbineElements.getConstantExpression(value))
           .isEqualTo(javacElements.getConstantExpression(value));
     }
+  }
+
+  @Test
+  public void getName() {
+    Name n = turbineElements.getName("hello");
+    assertThat(n.contentEquals("hello")).isTrue();
+    assertThat(n.contentEquals("goodbye")).isFalse();
+
+    assertThat(n.toString()).isEqualTo("hello");
+    assertThat(n.toString())
+        .isEqualTo(new String(new char[] {'h', 'e', 'l', 'l', 'o'})); // defeat interning
+
+    assertThat(n.length()).isEqualTo(5);
+
+    new EqualsTester()
+        .addEqualityGroup(turbineElements.getName("hello"), turbineElements.getName("hello"))
+        .addEqualityGroup(turbineElements.getName("goodbye"))
+        .testEquals();
   }
 }

--- a/javatests/com/google/turbine/processing/TurbineElementsTest.java
+++ b/javatests/com/google/turbine/processing/TurbineElementsTest.java
@@ -49,6 +49,7 @@ public class TurbineElementsTest {
           Joiner.on('\n')
               .join(
                   "=== Test.java ===",
+                  "@Deprecated",
                   "@A class Test extends One {}",
                   "=== One.java ===",
                   "@B class One extends Two {}",
@@ -174,5 +175,13 @@ public class TurbineElementsTest {
 
   private static ImmutableList<String> toStrings(List<?> inputs) {
     return inputs.stream().map(String::valueOf).collect(toImmutableList());
+  }
+
+  @Test
+  public void isDeprecated() {
+    assertThat(turbineElements.isDeprecated(turbineElements.getTypeElement("java.lang.Object")))
+        .isFalse();
+    assertThat(turbineElements.isDeprecated(turbineElements.getTypeElement("One"))).isFalse();
+    assertThat(turbineElements.isDeprecated(turbineElements.getTypeElement("Test"))).isTrue();
   }
 }

--- a/javatests/com/google/turbine/processing/TurbineElementsTest.java
+++ b/javatests/com/google/turbine/processing/TurbineElementsTest.java
@@ -18,6 +18,7 @@ package com.google.turbine.processing;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.base.Joiner;
@@ -35,8 +36,10 @@ import com.sun.source.util.JavacTask;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Name;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.util.Elements;
 import org.junit.Before;
 import org.junit.Test;
@@ -70,7 +73,17 @@ public class TurbineElementsTest {
                   "  int value() default 42;",
                   "}",
                   "@Inherited",
-                  "@interface D {}"));
+                  "@interface D {}",
+                  "=== com/pkg/P.java ===",
+                  "package com.pkg;",
+                  "@interface P {}",
+                  "=== com/pkg/package-info.java ===",
+                  "@P",
+                  "package com.pkg;",
+                  "=== Const.java ===",
+                  "class Const {",
+                  "  static final int X = 1867;",
+                  "}"));
 
   Elements javacElements;
   ModelFactory factory;
@@ -204,5 +217,16 @@ public class TurbineElementsTest {
                 .getDefaultValue()
                 .getValue())
         .isEqualTo(42);
+  }
+
+  @Test
+  public void constantFieldTest() {
+    assertThat(
+            ((VariableElement)
+                    turbineElements.getTypeElement("Const").getEnclosedElements().stream()
+                        .filter(x -> x.getKind().equals(ElementKind.FIELD))
+                        .collect(onlyElement()))
+                .getConstantValue())
+        .isEqualTo(1867);
   }
 }

--- a/javatests/com/google/turbine/processing/TurbineElementsTest.java
+++ b/javatests/com/google/turbine/processing/TurbineElementsTest.java
@@ -90,7 +90,7 @@ public class TurbineElementsTest {
     Env<ClassSymbol, TypeBoundClass> env =
         CompoundEnv.<ClassSymbol, TypeBoundClass>of(bound.classPathEnv())
             .append(new SimpleEnv<>(bound.units()));
-    factory = new ModelFactory(env, TurbineElementsTest.class.getClassLoader());
+    factory = new ModelFactory(env, TurbineElementsTest.class.getClassLoader(), bound.tli());
     TurbineTypes turbineTypes = new TurbineTypes(factory);
     turbineElements = new TurbineElements(factory, turbineTypes);
   }
@@ -158,6 +158,18 @@ public class TurbineElementsTest {
                     factory.typeElement(new ClassSymbol("Test")))))
         .containsExactlyElementsIn(
             toStrings(javacElements.getAllAnnotationMirrors(javacElements.getTypeElement("Test"))));
+  }
+
+  @Test
+  public void getTypeElement() {
+    for (String name : Arrays.asList("java.util.Map", "java.util.Map.Entry")) {
+      assertThat(turbineElements.getTypeElement(name).getQualifiedName().toString())
+          .isEqualTo(name);
+    }
+    assertThat(turbineElements.getTypeElement("NoSuch")).isNull();
+    assertThat(turbineElements.getTypeElement("java.lang.Object.NoSuch")).isNull();
+    assertThat(turbineElements.getTypeElement("java.lang.NoSuch")).isNull();
+    assertThat(turbineElements.getTypeElement("java.lang.Integer.MAX_VALUE")).isNull();
   }
 
   private static ImmutableList<String> toStrings(List<?> inputs) {

--- a/javatests/com/google/turbine/processing/TurbineElementsTest.java
+++ b/javatests/com/google/turbine/processing/TurbineElementsTest.java
@@ -122,7 +122,11 @@ public class TurbineElementsTest {
             Double.NEGATIVE_INFINITY,
             Double.POSITIVE_INFINITY,
             Double.MAX_VALUE,
-            Double.MIN_VALUE)) {
+            Double.MIN_VALUE,
+            'a',
+            '\n',
+            "hello",
+            "\"hello\n\"")) {
       assertThat(turbineElements.getConstantExpression(value))
           .isEqualTo(javacElements.getConstantExpression(value));
     }

--- a/javatests/com/google/turbine/processing/TurbineElementsTest.java
+++ b/javatests/com/google/turbine/processing/TurbineElementsTest.java
@@ -17,6 +17,7 @@
 package com.google.turbine.processing;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.base.Joiner;
@@ -34,6 +35,7 @@ import com.sun.source.util.JavacTask;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Name;
 import javax.lang.model.util.Elements;
 import org.junit.Before;
@@ -65,7 +67,7 @@ public class TurbineElementsTest {
                   "@interface B {}",
                   "@Inherited",
                   "@interface C {",
-                  "  int value();",
+                  "  int value() default 42;",
                   "}",
                   "@Inherited",
                   "@interface D {}"));
@@ -192,5 +194,15 @@ public class TurbineElementsTest {
                 .getBinaryName(turbineElements.getTypeElement("java.util.Map.Entry"))
                 .toString())
         .isEqualTo("java.util.Map$Entry");
+  }
+
+  @Test
+  public void methodDefaultTest() {
+    assertThat(
+            ((ExecutableElement)
+                    getOnlyElement(turbineElements.getTypeElement("C").getEnclosedElements()))
+                .getDefaultValue()
+                .getValue())
+        .isEqualTo(42);
   }
 }

--- a/javatests/com/google/turbine/processing/TurbineElementsTest.java
+++ b/javatests/com/google/turbine/processing/TurbineElementsTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.turbine.binder.Binder.BindingResult;
+import com.google.turbine.lower.IntegrationTestSupport;
+import com.google.turbine.testing.TestClassPaths;
+import java.util.Arrays;
+import java.util.Optional;
+import javax.lang.model.util.Elements;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TurbineElementsTest {
+
+  Elements javacElements;
+  TurbineElements turbineElements;
+
+  @Before
+  public void setup() throws Exception {
+    javacElements =
+        IntegrationTestSupport.runJavacAnalysis(
+                ImmutableMap.of("Test.java", "class Test {}"),
+                ImmutableList.of(),
+                ImmutableList.of())
+            .getElements();
+
+    BindingResult bound =
+        IntegrationTestSupport.turbineAnalysis(
+            ImmutableMap.of("Test.java", "class Test {}"),
+            ImmutableList.of(),
+            TestClassPaths.TURBINE_BOOTCLASSPATH,
+            Optional.empty());
+    ModelFactory factory =
+        new ModelFactory(bound.classPathEnv(), TurbineElementsTest.class.getClassLoader());
+    TurbineTypes turbineTypes = new TurbineTypes(factory);
+    turbineElements = new TurbineElements(factory, turbineTypes);
+  }
+
+  @Test
+  public void constants() {
+    for (Object value :
+        Arrays.asList(
+            Short.valueOf((short) 1),
+            Short.MIN_VALUE,
+            Short.MAX_VALUE,
+            Byte.valueOf((byte) 1),
+            Byte.MIN_VALUE,
+            Byte.MAX_VALUE,
+            Integer.valueOf(1),
+            Integer.MIN_VALUE,
+            Integer.MAX_VALUE,
+            Long.valueOf(1),
+            Long.MIN_VALUE,
+            Long.MAX_VALUE,
+            Float.valueOf(1),
+            Float.NaN,
+            Double.NEGATIVE_INFINITY,
+            Double.POSITIVE_INFINITY,
+            Float.MAX_VALUE,
+            Float.MIN_VALUE,
+            Double.valueOf(1),
+            Double.NaN,
+            Double.NEGATIVE_INFINITY,
+            Double.POSITIVE_INFINITY,
+            Double.MAX_VALUE,
+            Double.MIN_VALUE)) {
+      assertThat(turbineElements.getConstantExpression(value))
+          .isEqualTo(javacElements.getConstantExpression(value));
+    }
+  }
+}

--- a/javatests/com/google/turbine/processing/TurbineElementsTest.java
+++ b/javatests/com/google/turbine/processing/TurbineElementsTest.java
@@ -184,4 +184,13 @@ public class TurbineElementsTest {
     assertThat(turbineElements.isDeprecated(turbineElements.getTypeElement("One"))).isFalse();
     assertThat(turbineElements.isDeprecated(turbineElements.getTypeElement("Test"))).isTrue();
   }
+
+  @Test
+  public void getBinaryName() {
+    assertThat(
+            turbineElements
+                .getBinaryName(turbineElements.getTypeElement("java.util.Map.Entry"))
+                .toString())
+        .isEqualTo("java.util.Map$Entry");
+  }
 }

--- a/javatests/com/google/turbine/processing/TurbineFilerTest.java
+++ b/javatests/com/google/turbine/processing/TurbineFilerTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.fail;
+
+import com.google.common.base.Function;
+import com.google.common.base.Supplier;
+import com.google.common.io.ByteStreams;
+import com.google.common.io.CharStreams;
+import com.google.turbine.diag.SourceFile;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.processing.FilerException;
+import javax.lang.model.element.Element;
+import javax.tools.FileObject;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardLocation;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TurbineFilerTest {
+
+  private final Set<String> seen = new HashSet<>();
+  private TurbineFiler filer;
+
+  @Before
+  public void setup() {
+    Function<String, Supplier<byte[]>> classpath =
+        new Function<String, Supplier<byte[]>>() {
+          @Nullable
+          @Override
+          public Supplier<byte[]> apply(String input) {
+            return null;
+          }
+        };
+    this.filer = new TurbineFiler(seen, classpath, TurbineFilerTest.class.getClassLoader());
+  }
+
+  @Test
+  public void hello() throws IOException {
+    JavaFileObject sourceFile = filer.createSourceFile("com.foo.Bar", (Element[]) null);
+    try (OutputStream os = sourceFile.openOutputStream()) {
+      os.write("hello".getBytes(UTF_8));
+    }
+    assertThat(sourceFile.getLastModified()).isEqualTo(0);
+
+    JavaFileObject classFile = filer.createClassFile("com.foo.Baz", (Element[]) null);
+    try (OutputStream os = classFile.openOutputStream()) {
+      os.write("goodbye".getBytes(UTF_8));
+    }
+    assertThat(classFile.getLastModified()).isEqualTo(0);
+
+    Collection<SourceFile> roundSources = filer.finishRound();
+    assertThat(roundSources).hasSize(1);
+    assertThat(filer.generatedSources()).hasSize(1);
+    assertThat(filer.generatedClasses()).hasSize(1);
+
+    SourceFile source = getOnlyElement(roundSources);
+    assertThat(source.path()).isEqualTo("com/foo/Bar.java");
+    assertThat(source.source()).isEqualTo("hello");
+
+    Map.Entry<String, byte[]> clazz = getOnlyElement(filer.generatedClasses().entrySet());
+    assertThat(clazz.getKey()).isEqualTo("com/foo/Baz.class");
+    assertThat(new String(clazz.getValue(), UTF_8)).isEqualTo("goodbye");
+  }
+
+  @Test
+  public void existing() throws IOException {
+    seen.add("com/foo/Bar.java");
+    seen.add("com/foo/Baz.class");
+
+    try {
+      filer.createSourceFile("com.foo.Bar", (Element[]) null);
+      fail();
+    } catch (FilerException expected) {
+    }
+    filer.createSourceFile("com.foo.Baz", (Element[]) null);
+
+    filer.createClassFile("com.foo.Bar", (Element[]) null);
+    try {
+      filer.createClassFile("com.foo.Baz", (Element[]) null);
+      fail();
+    } catch (FilerException expected) {
+    }
+  }
+
+  @Test
+  public void get() throws IOException {
+    for (StandardLocation location :
+        Arrays.asList(
+            StandardLocation.CLASS_OUTPUT,
+            StandardLocation.SOURCE_OUTPUT,
+            StandardLocation.ANNOTATION_PROCESSOR_PATH,
+            StandardLocation.CLASS_PATH)) {
+      try {
+        filer.getResource(location, "", "NoSuch");
+        fail();
+      } catch (FileNotFoundException expected) {
+      }
+    }
+  }
+
+  @Test
+  public void sourceOutput() throws IOException {
+    JavaFileObject classFile = filer.createSourceFile("com.foo.Bar", (Element[]) null);
+    try (Writer writer = classFile.openWriter()) {
+      writer.write("hello");
+    }
+    filer.finishRound();
+
+    FileObject output = filer.getResource(StandardLocation.SOURCE_OUTPUT, "com.foo", "Bar.java");
+    assertThat(new String(ByteStreams.toByteArray(output.openInputStream()), UTF_8))
+        .isEqualTo("hello");
+    assertThat(output.getCharContent(false).toString()).isEqualTo("hello");
+    assertThat(CharStreams.toString(output.openReader(true))).isEqualTo("hello");
+  }
+
+  @Test
+  public void classOutput() throws IOException {
+    JavaFileObject classFile = filer.createClassFile("com.foo.Baz", (Element[]) null);
+    try (OutputStream os = classFile.openOutputStream()) {
+      os.write("goodbye".getBytes(UTF_8));
+    }
+    filer.finishRound();
+
+    FileObject output = filer.getResource(StandardLocation.CLASS_OUTPUT, "com.foo", "Baz.class");
+    assertThat(new String(ByteStreams.toByteArray(output.openInputStream()), UTF_8))
+        .isEqualTo("goodbye");
+    assertThat(output.getCharContent(false).toString()).isEqualTo("goodbye");
+    assertThat(CharStreams.toString(output.openReader(true))).isEqualTo("goodbye");
+  }
+
+  @Test
+  public void classpathResources() throws IOException {
+    FileObject resource =
+        filer.getResource(StandardLocation.ANNOTATION_PROCESSOR_PATH, "META-INF", "MANIFEST.MF");
+
+    assertThat(new String(ByteStreams.toByteArray(resource.openInputStream()), UTF_8))
+        .contains("Manifest-Version:");
+    assertThat(CharStreams.toString(resource.openReader(true))).contains("Manifest-Version:");
+    assertThat(resource.getCharContent(false).toString()).contains("Manifest-Version:");
+  }
+}

--- a/javatests/com/google/turbine/processing/TurbineTypeMirrorTest.java
+++ b/javatests/com/google/turbine/processing/TurbineTypeMirrorTest.java
@@ -46,7 +46,9 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class TurbineTypeMirrorTest {
 
-  private final ModelFactory factory = new ModelFactory(TestClassPaths.TURBINE_BOOTCLASSPATH.env());
+  private final ModelFactory factory =
+      new ModelFactory(
+          TestClassPaths.TURBINE_BOOTCLASSPATH.env(), ClassLoader.getSystemClassLoader());
 
   @Test
   public void primitiveTypes() {

--- a/javatests/com/google/turbine/processing/TurbineTypeMirrorTest.java
+++ b/javatests/com/google/turbine/processing/TurbineTypeMirrorTest.java
@@ -48,7 +48,9 @@ public class TurbineTypeMirrorTest {
 
   private final ModelFactory factory =
       new ModelFactory(
-          TestClassPaths.TURBINE_BOOTCLASSPATH.env(), ClassLoader.getSystemClassLoader());
+          TestClassPaths.TURBINE_BOOTCLASSPATH.env(),
+          ClassLoader.getSystemClassLoader(),
+          TestClassPaths.TURBINE_BOOTCLASSPATH.index());
 
   @Test
   public void primitiveTypes() {

--- a/javatests/com/google/turbine/processing/TurbineTypesUnaryTest.java
+++ b/javatests/com/google/turbine/processing/TurbineTypesUnaryTest.java
@@ -20,7 +20,10 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.common.truth.TruthJUnit.assume;
 import static org.junit.Assert.fail;
 
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
 import javax.lang.model.type.PrimitiveType;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
 import org.junit.Test;
@@ -98,5 +101,35 @@ public class TurbineTypesUnaryTest extends AbstractTurbineTypesTest {
     assertWithMessage("erasure(`%s`) = erasure(`%s`)", javacA, turbineA)
         .that(actual)
         .isEqualTo(expected);
+  }
+
+  private static final ImmutableSet<TypeKind> UNSUPPORTED_BY_DIRECT_SUPERTYPES =
+      ImmutableSet.of(TypeKind.EXECUTABLE, TypeKind.PACKAGE);
+
+  @Test
+  public void directSupertypes() {
+    assume().that(UNSUPPORTED_BY_DIRECT_SUPERTYPES).doesNotContain(javacA.getKind());
+
+    String expected = Joiner.on(", ").join(javacTypes.directSupertypes(javacA));
+    String actual = Joiner.on(", ").join(turbineTypes.directSupertypes(turbineA));
+    assertWithMessage("directSupertypes(`%s`) = directSupertypes(`%s`)", javacA, turbineA)
+        .that(actual)
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void directSupertypesThrows() {
+    assume().that(UNSUPPORTED_BY_DIRECT_SUPERTYPES).contains(javacA.getKind());
+
+    try {
+      javacTypes.directSupertypes(turbineA);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+    try {
+      turbineTypes.directSupertypes(turbineA);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
   }
 }

--- a/javatests/com/google/turbine/type/TypeTest.java
+++ b/javatests/com/google/turbine/type/TypeTest.java
@@ -16,11 +16,15 @@
 
 package com.google.turbine.type;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
 import com.google.turbine.binder.sym.ClassSymbol;
+import com.google.turbine.tree.Tree.Ident;
 import com.google.turbine.type.Type.ClassTy;
 import com.google.turbine.type.Type.ClassTy.SimpleClassTy;
+import com.google.turbine.type.Type.ErrorTy;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -47,5 +51,19 @@ public class TypeTest {
                 ImmutableList.of()))
         .addEqualityGroup(ClassTy.asNonParametricClassTy(new ClassSymbol("java/util/Map$Entry")))
         .testEquals();
+  }
+
+  private static final int NO_POSITION = -1;
+
+  @Test
+  public void error() {
+    assertThat(
+            ErrorTy.create(
+                    ImmutableList.of(
+                        new Ident(NO_POSITION, "com"),
+                        new Ident(NO_POSITION, "foo"),
+                        new Ident(NO_POSITION, "Bar")))
+                .name())
+        .isEqualTo("com.foo.Bar");
   }
 }


### PR DESCRIPTION
Moe Sync

This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Initial implementation of AnnotationMirror

ee53debc12b6fc405272f32cbc1fb2ae87e5ce9a

-------

<p> Implement annotation proxies

This allows annotation processors to interact with annotations using the core
reflection APIs, as long as the annotation definitions are present on the
annotation processor classpath. To support this, we create a proxy
implementation of the annotation interface.

1162a5596a040974e71613189223e6c88125f475

-------

<p> Implement Elements#getConstantExpression

b7a16aef81c699b10eb2214e3b90761cbd608be2

-------

<p> Implement Elements#getName

04538f8620ab26d6d7e2a1a5738013607bfc41f7

-------

<p> Implement Elements#getAllAnnotationMirrors

1a29c1cb355371be7dea70cb1a9a33686d3dd65c

-------

<p> Don't crash if a multi-variable declaration completes abruptly

e.g. `int x,;` instead of `int x,y;`.

fe4b842131d575af224aeaa8fd1c9131eb128878

-------

<p> Pass a log in to constant binding

to report errors for individual symbol resolution errors, instead of
failing on the first one. This will be helpful for supporting reduced
classpaths with annotation processing enabled.

af63597d2b08fbd6bf6d1dec6d79b8eaa5ebff15

-------

<p> Handle exceptions for non-generic methods

the signature is only provided for generic methods.

0ee3d1c5584db29b35c028c1dd0651277fd81d3c

-------

<p> Make ShortValue#toString consistent with documentation in TurbineElements#getConstantExpression

ShortValue#toString omits to the cast to `(short)` for consistency with javac.

f89d0c716d167e62e13f7a6a4a35f39d9e3f8277

-------

<p> Memoize TurbineElement#getAnnotationMirrors

848c86f04a98e774544cff457b2e4418dcb1cb15

-------

<p> Implement TypeElement#getSuperclass for Enums

776515813216264a477d31b232ad2935ca372e64

-------

<p> Fix Elements#getConstantExpression handling of String and char

4a5174b66499333a32b04fd4e4c6aa64129dfb23

-------

<p> Implement Types#directSupertypes

f084772e692a918366d85444077b258733360ea8

-------

<p> Implement Elements#getTypeElement

ec74afbdacc8891528b7b7145858e588b75d1f9c

-------

<p> Fix normalization of local classes

when comparing integration test output with javac we drop anonymous and local
classes, since they aren't part of the API and turbine doesn't generate them.

685466a828ca8d83b5f76250590221eabb250824

-------

<p> Fix TYPE_USE annotation handling on classes

dbaaba300a330f529cd602901b8a768b9145ddc3

-------

<p> Initial implementation of Filer

7962107ad8dd939a6e22d6e0825a8e8d2b1186ed

-------

<p> Implement Elements#isDeprecated

cdfd273a8cbd018d2d54cb4fb875a661ea5e1713

-------

<p> Implement Elements#getBinaryName

9426e945fc9b5282193008fe9b47f50b547844e6

-------

<p> Implement ExecutableElement#getDefaultValue

fe02bd7b2fbdfc16894eae38e5c1b46e991e234d

-------

<p> Implement VariableElement#getConstantValue

6161d46cfc436b5486e6fa384103a42353e074c5

-------

<p> Gracefully handle case where an annotation's @Target can't be loaded

e.g. because the annotation definition isn't on the classpath.

37be0de977af948294e8935cf9170eb99681a7ca

-------

<p> Save non-class resources from the classpath

1e4f8bf5a3e4d38edd88151ab42e829d07fe73b0

-------

<p> Save names of ErrorTypes

To improve their representation in the annotation processing API.

aa0879c9a65aba86081c759bdd49e13b39f7a794

-------

<p> Make TurbinePackageType.hashCode() differ for different package types

I'm not sure how common people will actually hash these, but I figure it can't hurt

d260bea0cf50d308413f6d4b813621c279ec4afe

-------

<p> Make TurbineElement.getModifiers() immutable

I kept an EnumSet in asModifierSet so that it would still be space-efficient, but if that's not a concern, I can have it use a regular ImmutableSet.Builder

9d9884162a074b0211cf6febf559554a4279ba3c

-------

<p> Simplify TurbineTypeElement.enclosing()

e12e178a0340c1ffded500931020c064fb41b195
