### PR TITLE
Moe Sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk9
   - openjdk10
   - openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 
 jdk:
   - oraclejdk8
-  - oraclejdk9
+  - openjdk9
   - openjdk10
   - openjdk11
   - openjdk-ea

--- a/java/com/google/turbine/main/Main.java
+++ b/java/com/google/turbine/main/Main.java
@@ -119,7 +119,14 @@ public class Main {
     ClassPath bootclasspath = bootclasspath(options);
 
     BindingResult bound;
-    switch (options.reducedClasspathMode()) {
+    ReducedClasspathMode reducedClasspathMode = options.reducedClasspathMode();
+    if (reducedClasspathMode == ReducedClasspathMode.JAVABUILDER_REDUCED
+        && options.directJars().isEmpty()) {
+      // the compilation doesn't support reduced classpaths
+      // TODO(cushon): make this a usage error, see TODO in Dependencies.reduceClasspath
+      reducedClasspathMode = ReducedClasspathMode.NONE;
+    }
+    switch (reducedClasspathMode) {
       case NONE:
       case BAZEL_FALLBACK:
         bound = bind(options, units, bootclasspath, options.classPath());
@@ -147,7 +154,7 @@ public class Main {
         }
         break;
       default:
-        throw new AssertionError(options.reducedClasspathMode());
+        throw new AssertionError(reducedClasspathMode);
     }
 
     // TODO(cushon): parallelize

--- a/java/com/google/turbine/main/Main.java
+++ b/java/com/google/turbine/main/Main.java
@@ -131,7 +131,7 @@ public class Main {
         try {
           bound = bind(options, units, bootclasspath, reducedClasspath);
         } catch (TurbineError e) {
-          e.printStackTrace(out);
+          out.println(e.getMessage());
           out.println("warning: falling back to transitive classpath");
           bound = bind(options, units, bootclasspath, options.classPath());
         }
@@ -140,7 +140,7 @@ public class Main {
         try {
           bound = bind(options, units, bootclasspath, options.classPath());
         } catch (TurbineError e) {
-          e.printStackTrace(out);
+          out.println(e.getMessage());
           out.println("warning: falling back to transitive classpath");
           writeJdepsForFallback(options);
           return true;

--- a/java/com/google/turbine/options/TurbineOptions.java
+++ b/java/com/google/turbine/options/TurbineOptions.java
@@ -67,7 +67,6 @@ public class TurbineOptions {
   private final Optional<String> targetLabel;
   private final Optional<String> injectingRuleKind;
   private final ImmutableList<String> depsArtifacts;
-  private final boolean javacFallback;
   private final boolean help;
   private final ImmutableList<String> javacOpts;
   private final ReducedClasspathMode reducedClasspathMode;
@@ -90,7 +89,6 @@ public class TurbineOptions {
       @Nullable String targetLabel,
       @Nullable String injectingRuleKind,
       ImmutableList<String> depsArtifacts,
-      boolean javacFallback,
       boolean help,
       ImmutableList<String> javacOpts,
       ReducedClasspathMode reducedClasspathMode,
@@ -111,7 +109,6 @@ public class TurbineOptions {
     this.targetLabel = Optional.ofNullable(targetLabel);
     this.injectingRuleKind = Optional.ofNullable(injectingRuleKind);
     this.depsArtifacts = checkNotNull(depsArtifacts, "depsArtifacts must not be null");
-    this.javacFallback = javacFallback;
     this.help = help;
     this.javacOpts = checkNotNull(javacOpts, "javacOpts must not be null");
     this.reducedClasspathMode = reducedClasspathMode;
@@ -210,11 +207,6 @@ public class TurbineOptions {
     return depsArtifacts;
   }
 
-  /** Fall back to javac-turbine for error reporting. */
-  public boolean javacFallback() {
-    return javacFallback;
-  }
-
   /** Print usage information. */
   public boolean help() {
     return help;
@@ -280,7 +272,6 @@ public class TurbineOptions {
     @Nullable private String targetLabel;
     @Nullable private String injectingRuleKind;
     private final ImmutableList.Builder<String> depsArtifacts = ImmutableList.builder();
-    private boolean javacFallback = true;
     private boolean help = false;
     private final ImmutableList.Builder<String> javacOpts = ImmutableList.builder();
     private ReducedClasspathMode reducedClasspathMode = ReducedClasspathMode.JAVABUILDER_REDUCED;
@@ -304,7 +295,6 @@ public class TurbineOptions {
           targetLabel,
           injectingRuleKind,
           depsArtifacts.build(),
-          javacFallback,
           help,
           javacOpts.build(),
           reducedClasspathMode,
@@ -384,11 +374,6 @@ public class TurbineOptions {
 
     public Builder addAllDepsArtifacts(Iterable<String> depsArtifacts) {
       this.depsArtifacts.addAll(depsArtifacts);
-      return this;
-    }
-
-    public Builder setJavacFallback(boolean javacFallback) {
-      this.javacFallback = javacFallback;
       return this;
     }
 

--- a/java/com/google/turbine/options/TurbineOptionsParser.java
+++ b/java/com/google/turbine/options/TurbineOptionsParser.java
@@ -116,10 +116,8 @@ public class TurbineOptionsParser {
           builder.setInjectingRuleKind(readOne(argumentDeque));
           break;
         case "--javac_fallback":
-          builder.setJavacFallback(true);
-          break;
         case "--nojavac_fallback":
-          builder.setJavacFallback(false);
+          // TODO(cushon): remove this case once blaze stops passing the flag
           break;
         case "--reduce_classpath":
           builder.setReducedClasspathMode(ReducedClasspathMode.JAVABUILDER_REDUCED);

--- a/java/com/google/turbine/processing/TurbineElement.java
+++ b/java/com/google/turbine/processing/TurbineElement.java
@@ -750,8 +750,9 @@ public abstract class TurbineElement implements Element {
 
     @Override
     public TypeMirror getReceiverType() {
-      // TODO(cushon): javac returns null, the spec says NONE
-      return info().receiver() != null ? factory.asTypeMirror(info().receiver().type()) : null;
+      return info().receiver() != null
+          ? factory.asTypeMirror(info().receiver().type())
+          : factory.noType();
     }
 
     @Override

--- a/javatests/com/google/turbine/main/ReducedClasspathTest.java
+++ b/javatests/com/google/turbine/main/ReducedClasspathTest.java
@@ -170,8 +170,12 @@ public class ReducedClasspathTest {
                 .addAllDepsArtifacts(ImmutableList.of(libcJdeps.toString()))
                 .build(),
             new PrintWriter(sw, true));
-    assertThat(sw.toString()).contains("warning: falling back to transitive classpath");
-    assertThat(sw.toString()).contains("could not resolve I");
+    assertThat(sw.toString())
+        .isEqualTo(
+            (src + ":3: error: could not resolve I\n")
+                + "  I i;\n"
+                + "  ^\n"
+                + "warning: falling back to transitive classpath\n");
     assertThat(ok).isTrue();
   }
 
@@ -202,8 +206,12 @@ public class ReducedClasspathTest {
                 .addClassPathEntries(ImmutableList.of(libc.toString()))
                 .build(),
             new PrintWriter(sw, true));
-    assertThat(sw.toString()).contains("warning: falling back to transitive classpath");
-    assertThat(sw.toString()).contains("could not resolve I");
+    assertThat(sw.toString())
+        .isEqualTo(
+            (src + ":3: error: could not resolve I\n")
+                + "  I i;\n"
+                + "  ^\n"
+                + "warning: falling back to transitive classpath\n");
     assertThat(ok).isTrue();
     DepsProto.Dependencies.Builder deps = DepsProto.Dependencies.newBuilder();
     try (InputStream is = new BufferedInputStream(Files.newInputStream(jdeps))) {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove obsolete and unused 'javac fallback' flag

e3c68e98d0cfbf188d0a315e7096d56a162d865c

-------

<p> Don't print stack traces for failing compilations

31c7ead26a3c131120e6bc5453d4d864a06c9621

-------

<p> Avoid unnecessary local fallback to the transitive classpath

if direct deps weren't available. In the future enabling reduced classpaths
without providing direct deps will be a usage error. This improves failure
messages and saves a bit of time for failing builds in the interim.

d769c60662d6407438145cf9c71af6fe96bb0707

-------

<p> Switch from oraclejdk9 to openjdk9 in Travis builds, per https://travis-ci.community/t/java-9-build-failing-with-https-certificate-exception/4364/2.

3e8ca774b7cb88cb8ef49b3241c4777e839c189e

-------

<p> Changing oraclejdk8 to openjdk8 in hopes that it will fix our Travis builds.

30f81df479ba6b2592fffafee12f8192438e0dd8

-------

<p> Remove javac bug compatibility work-around

the bug is fixed in JDK 14 and isn't load-bearing, see:
https://bugs.openjdk.java.net/browse/JDK-8222369

e3f549ca9751ad893b58353281b38296ce9b7189