### PR TITLE
Fix AppVeyor build by accepting Windows line separators.

### DIFF
--- a/java/com/google/turbine/diag/TurbineError.java
+++ b/java/com/google/turbine/diag/TurbineError.java
@@ -90,7 +90,7 @@ public class TurbineError extends Error {
   private final ImmutableList<TurbineDiagnostic> diagnostics;
 
   public TurbineError(ImmutableList<TurbineDiagnostic> diagnostics) {
-    super(diagnostics.stream().map(d -> d.diagnostic()).collect(joining("\n")));
+    super(diagnostics.stream().map(d -> d.diagnostic()).collect(joining(System.lineSeparator())));
     this.diagnostics = diagnostics;
   }
 

--- a/javatests/com/google/turbine/lower/LowerTest.java
+++ b/javatests/com/google/turbine/lower/LowerTest.java
@@ -356,7 +356,7 @@ public class LowerTest {
                       int typeRef, TypePath typePath, String desc, boolean visible) {
                     path[0] = typePath;
                     return null;
-                  };
+                  }
                 };
               }
             },
@@ -610,9 +610,10 @@ public class LowerTest {
       assertThat(error)
           .hasMessageThat()
           .contains(
-              "Test.java:3: error: could not locate class file for A\n"
-                  + "     I i;\n"
-                  + "       ^");
+              lines(
+                  "Test.java:3: error: could not locate class file for A",
+                  "     I i;",
+                  "       ^"));
     }
   }
 
@@ -646,6 +647,6 @@ public class LowerTest {
   }
 
   static String lines(String... lines) {
-    return Joiner.on("\n").join(lines);
+    return Joiner.on(System.lineSeparator()).join(lines);
   }
 }

--- a/javatests/com/google/turbine/main/ReducedClasspathTest.java
+++ b/javatests/com/google/turbine/main/ReducedClasspathTest.java
@@ -22,6 +22,7 @@ import static com.google.turbine.testing.TestClassPaths.optionsWithBootclasspath
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.fail;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.turbine.diag.TurbineError;
 import com.google.turbine.lower.IntegrationTestSupport;
@@ -174,10 +175,12 @@ public class ReducedClasspathTest {
             new PrintWriter(sw, true));
     assertThat(sw.toString())
         .isEqualTo(
-            (src + ":3: error: could not resolve I\n")
-                + "  I i;\n"
-                + "  ^\n"
-                + "warning: falling back to transitive classpath\n");
+            lines(
+                src + ":3: error: could not resolve I",
+                "  I i;",
+                "  ^",
+                "warning: falling back to transitive classpath",
+                ""));
     assertThat(ok).isTrue();
   }
 
@@ -210,10 +213,12 @@ public class ReducedClasspathTest {
             new PrintWriter(sw, true));
     assertThat(sw.toString())
         .isEqualTo(
-            (src + ":3: error: could not resolve I\n")
-                + "  I i;\n"
-                + "  ^\n"
-                + "warning: falling back to transitive classpath\n");
+            lines(
+                src + ":3: error: could not resolve I",
+                "  I i;",
+                "  ^",
+                "warning: falling back to transitive classpath",
+                ""));
     assertThat(ok).isTrue();
     DepsProto.Dependencies.Builder deps = DepsProto.Dependencies.newBuilder();
     try (InputStream is = new BufferedInputStream(Files.newInputStream(jdeps))) {
@@ -257,5 +262,9 @@ public class ReducedClasspathTest {
       assertThat(e).hasMessageThat().contains("could not resolve I");
     }
     assertThat(sw.toString()).doesNotContain("warning: falling back to transitive classpath");
+  }
+
+  static String lines(String... lines) {
+    return Joiner.on(System.lineSeparator()).join(lines);
   }
 }


### PR DESCRIPTION
Example failure: https://ci.appveyor.com/project/cushon/turbine/builds/26859701/job/3446g6sd9l3yw5da
Successful build for this CL in pull-request form: https://ci.appveyor.com/project/cushon/turbine/builds/26861707

I haven't dug into exactly when the failures started, but it looks like the first one was close to a year ago.

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=264632479