### PR TITLE
Moe Sync

### DIFF
--- a/java/com/google/turbine/binder/ConstEvaluator.java
+++ b/java/com/google/turbine/binder/ConstEvaluator.java
@@ -981,7 +981,7 @@ public strictfp class ConstEvaluator {
     if (sym == null) {
       return null;
     }
-    AnnoInfo annoInfo = evaluateAnnotation(new AnnoInfo(source, sym, t, null));
+    AnnoInfo annoInfo = evaluateAnnotation(new AnnoInfo(source, sym, t, ImmutableMap.of()));
     return new TurbineAnnotationValue(annoInfo);
   }
 

--- a/java/com/google/turbine/binder/ModuleBinder.java
+++ b/java/com/google/turbine/binder/ModuleBinder.java
@@ -102,7 +102,7 @@ public class ModuleBinder {
     ImmutableList.Builder<AnnoInfo> annoInfos = ImmutableList.builder();
     for (Tree.Anno annoTree : module.module().annos()) {
       ClassSymbol sym = resolve(annoTree.position(), annoTree.name());
-      annoInfos.add(new AnnoInfo(module.source(), sym, annoTree, null));
+      annoInfos.add(new AnnoInfo(module.source(), sym, annoTree, ImmutableMap.of()));
     }
     ImmutableList<AnnoInfo> annos = constEvaluator.evaluateAnnotations(annoInfos.build());
 

--- a/java/com/google/turbine/binder/TypeBinder.java
+++ b/java/com/google/turbine/binder/TypeBinder.java
@@ -570,7 +570,7 @@ public class TypeBinder {
       ImmutableList<Ident> name = tree.name();
       LookupResult lookupResult = scope.lookup(new LookupKey(name));
       ClassSymbol sym = resolveAnnoSymbol(tree, name, lookupResult);
-      result.add(new AnnoInfo(base.source(), sym, tree, null));
+      result.add(new AnnoInfo(base.source(), sym, tree, ImmutableMap.of()));
     }
     return result.build();
   }

--- a/java/com/google/turbine/diag/TurbineLog.java
+++ b/java/com/google/turbine/diag/TurbineLog.java
@@ -18,6 +18,7 @@ package com.google.turbine.diag;
 
 import com.google.common.collect.ImmutableList;
 import com.google.turbine.diag.TurbineError.ErrorKind;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import javax.tools.Diagnostic;
@@ -64,7 +65,12 @@ public class TurbineLog {
 
   /** Reset the log between annotation processing rounds. */
   public void clear() {
-    errors.clear();
+    Iterator<TurbineDiagnostic> it = errors.iterator();
+    while (it.hasNext()) {
+      if (it.next().severity().equals(Diagnostic.Kind.ERROR)) {
+        it.remove();
+      }
+    }
   }
 
   /** Reports an annotation processing diagnostic with no position information. */

--- a/java/com/google/turbine/processing/TurbineElement.java
+++ b/java/com/google/turbine/processing/TurbineElement.java
@@ -63,6 +63,7 @@ import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
@@ -118,7 +119,7 @@ public abstract class TurbineElement implements Element {
 
   static AnnoInfo getAnnotation(Iterable<AnnoInfo> annos, ClassSymbol sym) {
     for (AnnoInfo anno : annos) {
-      if (anno.sym().equals(sym)) {
+      if (Objects.equals(anno.sym(), sym)) {
         return anno;
       }
     }

--- a/java/com/google/turbine/processing/TurbineMessager.java
+++ b/java/com/google/turbine/processing/TurbineMessager.java
@@ -33,6 +33,7 @@ import com.google.turbine.diag.SourceFile;
 import com.google.turbine.diag.TurbineError;
 import com.google.turbine.diag.TurbineLog;
 import com.google.turbine.model.Const;
+import com.google.turbine.processing.TurbineElement.TurbineNoTypeElement;
 import com.google.turbine.tree.Tree;
 import com.google.turbine.type.AnnoInfo;
 import java.util.Iterator;
@@ -61,7 +62,7 @@ class TurbineMessager implements Messager {
 
   @Override
   public void printMessage(Diagnostic.Kind kind, CharSequence msg, Element e) {
-    if (e == null) {
+    if (e == null || e instanceof TurbineNoTypeElement) {
       printMessage(kind, msg);
       return;
     }
@@ -73,7 +74,7 @@ class TurbineMessager implements Messager {
 
   @Override
   public void printMessage(Diagnostic.Kind kind, CharSequence msg, Element e, AnnotationMirror a) {
-    if (a == null || e == null) {
+    if (a == null || e == null || e instanceof TurbineNoTypeElement) {
       printMessage(kind, msg, e);
       return;
     }
@@ -85,7 +86,7 @@ class TurbineMessager implements Messager {
   @Override
   public void printMessage(
       Diagnostic.Kind kind, CharSequence msg, Element e, AnnotationMirror a, AnnotationValue v) {
-    if (a == null || e == null || v == null) {
+    if (a == null || e == null || e instanceof TurbineNoTypeElement || v == null) {
       printMessage(kind, msg, e, a);
       return;
     }

--- a/java/com/google/turbine/type/AnnoInfo.java
+++ b/java/com/google/turbine/type/AnnoInfo.java
@@ -17,6 +17,7 @@
 package com.google.turbine.type;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -41,7 +42,7 @@ public class AnnoInfo {
     this.source = source;
     this.sym = sym;
     this.tree = tree;
-    this.values = values;
+    this.values = requireNonNull(values);
   }
 
   /** The annotation's source, for diagnostics. */

--- a/javatests/com/google/turbine/processing/ProcessingIntegrationTest.java
+++ b/javatests/com/google/turbine/processing/ProcessingIntegrationTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.turbine.processing;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.turbine.binder.Binder;
+import com.google.turbine.binder.ClassPathBinder;
+import com.google.turbine.binder.Processing;
+import com.google.turbine.diag.SourceFile;
+import com.google.turbine.diag.TurbineError;
+import com.google.turbine.lower.IntegrationTestSupport;
+import com.google.turbine.parse.Parser;
+import com.google.turbine.testing.TestClassPaths;
+import com.google.turbine.tree.Tree;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ProcessingIntegrationTest {
+
+  @SupportedAnnotationTypes("*")
+  public static class CrashingProcessor extends AbstractProcessor {
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+      return SourceVersion.latestSupported();
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+      throw new RuntimeException("crash!");
+    }
+  }
+
+  private static final IntegrationTestSupport.TestInput SOURCES =
+      IntegrationTestSupport.TestInput.parse(
+          Joiner.on('\n')
+              .join(
+                  "=== Test.java ===", //
+                  "@Deprecated",
+                  "class Test extends NoSuch {",
+                  "}"));
+
+  @Test
+  public void crash() throws IOException {
+    ImmutableList<Tree.CompUnit> units =
+        SOURCES.sources.entrySet().stream()
+            .map(e -> new SourceFile(e.getKey(), e.getValue()))
+            .map(Parser::parse)
+            .collect(toImmutableList());
+    try {
+      Binder.bind(
+          units,
+          ClassPathBinder.bindClasspath(ImmutableList.of()),
+          Processing.ProcessorInfo.create(
+              ImmutableList.of(new CrashingProcessor()),
+              getClass().getClassLoader(),
+              ImmutableMap.of(),
+              SourceVersion.latestSupported()),
+          TestClassPaths.TURBINE_BOOTCLASSPATH,
+          Optional.empty());
+      fail();
+    } catch (TurbineError e) {
+      assertThat(e.diagnostics()).hasSize(2);
+      assertThat(e.diagnostics().get(0).message()).contains("could not resolve NoSuch");
+      assertThat(e.diagnostics().get(1).message()).contains("crash!");
+    }
+  }
+}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Handle unchecked exceptions thrown by annotation processors

29a3837641a9ff5cd895b54a56fe550ca4592aca

-------

<p> Preserve non-error diagnostics across annotation processing rounds

errors are reset since they may be resolved by code generated in later rounds,
but non-error diagnostics need to be preserved to match javac, which eagerly
reports non-error diagnostics from processors.

805d9c0cbbfb0a7705a3d074635e14a634abb2b8

-------

<p> Fix an NPE

56ed50fcb988363e0f2083b347e5e461a4fd86ee