### PR TITLE
Moe Sync

### DIFF
--- a/java/com/google/turbine/binder/HierarchyBinder.java
+++ b/java/com/google/turbine/binder/HierarchyBinder.java
@@ -16,6 +16,7 @@
 
 package com.google.turbine.binder;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.turbine.binder.bound.HeaderBoundClass;
@@ -120,7 +121,7 @@ public class HierarchyBinder {
     // Resolve the base symbol in the qualified name.
     LookupResult result = lookup(ty, new LookupKey(ImmutableList.copyOf(flat)));
     if (result == null) {
-      log.error(ty.position(), ErrorKind.CANNOT_RESOLVE, ty);
+      log.error(ty.position(), ErrorKind.CANNOT_RESOLVE, Joiner.on('.').join(flat));
       return null;
     }
     // Resolve pieces in the qualified name referring to member types.

--- a/java/com/google/turbine/diag/SourceFile.java
+++ b/java/com/google/turbine/diag/SourceFile.java
@@ -16,6 +16,8 @@
 
 package com.google.turbine.diag;
 
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import java.util.Objects;
 
 /** A source file. */
@@ -23,6 +25,15 @@ public class SourceFile {
 
   private final String path;
   private final String source;
+
+  private final Supplier<LineMap> lineMap =
+      Suppliers.memoize(
+          new Supplier<LineMap>() {
+            @Override
+            public LineMap get() {
+              return LineMap.create(source);
+            }
+          });
 
   public SourceFile(String path, String source) {
     this.path = path;
@@ -37,6 +48,10 @@ public class SourceFile {
   /** The source. */
   public String source() {
     return source;
+  }
+
+  LineMap lineMap() {
+    return lineMap.get();
   }
 
   @Override

--- a/java/com/google/turbine/diag/SourceFile.java
+++ b/java/com/google/turbine/diag/SourceFile.java
@@ -16,6 +16,8 @@
 
 package com.google.turbine.diag;
 
+import java.util.Objects;
+
 /** A source file. */
 public class SourceFile {
 
@@ -43,7 +45,7 @@ public class SourceFile {
       return false;
     }
     SourceFile that = (SourceFile) obj;
-    return path.equals(that.path) && source.equals(that.source);
+    return Objects.equals(path, that.path) && source.equals(that.source);
   }
 
   @Override

--- a/java/com/google/turbine/diag/TurbineDiagnostic.java
+++ b/java/com/google/turbine/diag/TurbineDiagnostic.java
@@ -22,8 +22,6 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Strings;
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.turbine.binder.sym.ClassSymbol;
 import com.google.turbine.diag.TurbineError.ErrorKind;
@@ -39,14 +37,6 @@ public class TurbineDiagnostic {
   private final ImmutableList<Object> args;
   private final @Nullable SourceFile source;
   private final int position;
-  private final Supplier<LineMap> lineMap =
-      Suppliers.memoize(
-          new Supplier<LineMap>() {
-            @Override
-            public LineMap get() {
-              return LineMap.create(source.source());
-            }
-          });
 
   private TurbineDiagnostic(
       Diagnostic.Kind severity,
@@ -83,7 +73,7 @@ public class TurbineDiagnostic {
     sb.append(": error: ");
     sb.append(message().trim()).append(System.lineSeparator());
     if (line() != -1 && column() != -1) {
-      sb.append(CharMatcher.breakingWhitespace().trimTrailingFrom(lineMap.get().line(position)))
+      sb.append(CharMatcher.breakingWhitespace().trimTrailingFrom(source.lineMap().line(position)))
           .append(System.lineSeparator());
       sb.append(Strings.repeat(" ", column() - 1)).append('^');
     }
@@ -166,11 +156,11 @@ public class TurbineDiagnostic {
   }
 
   public int line() {
-    return position != -1 ? lineMap.get().lineNumber(position) : -1;
+    return position != -1 ? source.lineMap().lineNumber(position) : -1;
   }
 
   public int column() {
-    return position != -1 ? lineMap.get().column(position) + 1 : -1;
+    return position != -1 ? source.lineMap().column(position) + 1 : -1;
   }
 
   public String message() {

--- a/java/com/google/turbine/diag/TurbineDiagnostic.java
+++ b/java/com/google/turbine/diag/TurbineDiagnostic.java
@@ -29,6 +29,7 @@ import com.google.turbine.binder.sym.ClassSymbol;
 import com.google.turbine.diag.TurbineError.ErrorKind;
 import java.util.Objects;
 import javax.tools.Diagnostic;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** A compilation error. */
 public class TurbineDiagnostic {
@@ -36,7 +37,7 @@ public class TurbineDiagnostic {
   private final Diagnostic.Kind severity;
   private final ErrorKind kind;
   private final ImmutableList<Object> args;
-  private final SourceFile source;
+  private final @Nullable SourceFile source;
   private final int position;
   private final Supplier<LineMap> lineMap =
       Suppliers.memoize(
@@ -51,7 +52,7 @@ public class TurbineDiagnostic {
       Diagnostic.Kind severity,
       ErrorKind kind,
       ImmutableList<Object> args,
-      SourceFile source,
+      @Nullable SourceFile source,
       int position) {
     this.severity = requireNonNull(severity);
     this.kind = requireNonNull(kind);
@@ -149,8 +150,15 @@ public class TurbineDiagnostic {
 
   @Override
   public boolean equals(Object obj) {
-    return obj instanceof TurbineDiagnostic
-        && diagnostic().equals(((TurbineDiagnostic) obj).diagnostic());
+    if (!(obj instanceof TurbineDiagnostic)) {
+      return false;
+    }
+    TurbineDiagnostic that = (TurbineDiagnostic) obj;
+    return severity.equals(that.severity)
+        && kind.equals(that.kind)
+        && args.equals(that.args)
+        && Objects.equals(source, that.source)
+        && position == that.position;
   }
 
   public String path() {

--- a/java/com/google/turbine/diag/TurbineError.java
+++ b/java/com/google/turbine/diag/TurbineError.java
@@ -90,8 +90,12 @@ public class TurbineError extends Error {
   private final ImmutableList<TurbineDiagnostic> diagnostics;
 
   public TurbineError(ImmutableList<TurbineDiagnostic> diagnostics) {
-    super(diagnostics.stream().map(d -> d.diagnostic()).collect(joining(System.lineSeparator())));
     this.diagnostics = diagnostics;
+  }
+
+  @Override
+  public String getMessage() {
+    return diagnostics.stream().map(d -> d.diagnostic()).collect(joining(System.lineSeparator()));
   }
 
   public ImmutableList<TurbineDiagnostic> diagnostics() {

--- a/java/com/google/turbine/main/Main.java
+++ b/java/com/google/turbine/main/Main.java
@@ -161,7 +161,7 @@ public class Main {
         try {
           bound = bind(options, units, bootclasspath, reducedClasspath);
         } catch (TurbineError e) {
-          bound = bind(options, units, bootclasspath, classPath);
+          bound = fallback(options, units, bootclasspath, classPath);
           transitiveClasspathFallback = true;
         }
         break;
@@ -203,6 +203,16 @@ public class Main {
         /* transitiveClasspathLength= */ transitiveClasspathLength,
         /* reducedClasspathLength= */ reducedClasspathLength,
         bound.statistics());
+  }
+
+  // don't inline this; we want it to show up in profiles
+  private static BindingResult fallback(
+      TurbineOptions options,
+      ImmutableList<CompUnit> units,
+      ClassPath bootclasspath,
+      ImmutableList<String> classPath)
+      throws IOException {
+    return bind(options, units, bootclasspath, classPath);
   }
 
   /**

--- a/java/com/google/turbine/main/Main.java
+++ b/java/com/google/turbine/main/Main.java
@@ -21,11 +21,11 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.Hashing;
 import com.google.common.io.MoreFiles;
 import com.google.turbine.binder.Binder;
 import com.google.turbine.binder.Binder.BindingResult;
+import com.google.turbine.binder.Binder.Statistics;
 import com.google.turbine.binder.ClassPath;
 import com.google.turbine.binder.ClassPathBinder;
 import com.google.turbine.binder.CtSymClassBinder;
@@ -107,13 +107,13 @@ public class Main {
      */
     public abstract int reducedClasspathLength();
 
-    public abstract ImmutableMap<String, byte[]> processorStatistics();
+    public abstract Statistics processorStatistics();
 
     static Result create(
         boolean transitiveClasspathFallback,
         int transitiveClasspathLength,
         int reducedClasspathLength,
-        ImmutableMap<String, byte[]> processorStatistics) {
+        Statistics processorStatistics) {
       return new AutoValue_Main_Result(
           transitiveClasspathFallback,
           transitiveClasspathLength,
@@ -175,7 +175,7 @@ public class Main {
               /* transitiveClasspathFallback= */ true,
               /* transitiveClasspathLength= */ transitiveClasspathLength,
               /* reducedClasspathLength= */ reducedClasspathLength,
-              /* processorStatistics= */ ImmutableMap.of());
+              Statistics.empty());
         }
         break;
       default:
@@ -202,7 +202,7 @@ public class Main {
         /* transitiveClasspathFallback= */ transitiveClasspathFallback,
         /* transitiveClasspathLength= */ transitiveClasspathLength,
         /* reducedClasspathLength= */ reducedClasspathLength,
-        /* processorStatistics= */ bound.statistics());
+        bound.statistics());
   }
 
   /**

--- a/java/com/google/turbine/options/TurbineOptions.java
+++ b/java/com/google/turbine/options/TurbineOptions.java
@@ -288,7 +288,7 @@ public class TurbineOptions {
     private final ImmutableList.Builder<String> depsArtifacts = ImmutableList.builder();
     private boolean help = false;
     private final ImmutableList.Builder<String> javacOpts = ImmutableList.builder();
-    private ReducedClasspathMode reducedClasspathMode = ReducedClasspathMode.JAVABUILDER_REDUCED;
+    private ReducedClasspathMode reducedClasspathMode = ReducedClasspathMode.NONE;
     private @Nullable String profile;
     private @Nullable String gensrcOutput;
     private int fullClasspathLength;

--- a/javatests/com/google/turbine/options/TurbineOptionsTest.java
+++ b/javatests/com/google/turbine/options/TurbineOptionsTest.java
@@ -96,7 +96,8 @@ public class TurbineOptionsTest {
     assertThat(options.outputDeps()).hasValue("out.jdeps");
     assertThat(options.targetLabel()).hasValue("//java/com/google/test");
     assertThat(options.injectingRuleKind()).hasValue("foo_library");
-    assertThat(options.shouldReduceClassPath()).isTrue();
+    assertThat(options.reducedClasspathMode()).isEqualTo(ReducedClasspathMode.NONE);
+    assertThat(options.shouldReduceClassPath()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Record time spent in annotation processors

RELNOTES: none

b2926362d6c35194a249bc2739d00bc454a5becb

-------

<p> Outline a method for reduced classpath fallback

so it stands out in profiles.

a9b86541b52e734825585c891337cb9cee0a10b9

-------

<p> Create TurbineError messages lazily

during reduced classpath fallback the message is never used, so we want to
defer the work of creating it.

2f0bd946c159a29a45aa1f4f117dfdd344a4caac

-------

<p> Optimize TurbineDiagnostic.equals

to avoid creating textual diagnostics, which is expensive because it requires a
line map.

2a29b882ee8f7d2651f2bf4e1acdc1f904a4dab9

-------

<p> Move LineMap creation into SourceFile

so one line map is created per source file, not one per diagnostic per source file.

eae56716136bb097c7920a6841c3c1ef9d7a8a88

-------

<p> Disable in-process reduced classpath fallback by default

for parity with JavaBuilder. This is currently interacting with bazel-side
fallback and causing fallback to happen twice: once in bazel, and once
in-process.

ebf9dfa66184b4d6d5f2b5d72ef9e237b6afdfed