### PR TITLE
Moe Sync

### DIFF
--- a/java/com/google/turbine/options/TurbineOptions.java
+++ b/java/com/google/turbine/options/TurbineOptions.java
@@ -223,24 +223,6 @@ public class TurbineOptions {
     return javacOpts;
   }
 
-  /**
-   * Returns true if the reduced classpath optimization is enabled.
-   *
-   * @deprecated use {@link #reducedClasspathMode} instead.
-   */
-  @Deprecated
-  public boolean shouldReduceClassPath() {
-    switch (reducedClasspathMode) {
-      case JAVABUILDER_REDUCED:
-        return true;
-      case BAZEL_REDUCED:
-      case BAZEL_FALLBACK:
-      case NONE:
-        return false;
-    }
-    throw new AssertionError(reducedClasspathMode);
-  }
-
   /** The reduced classpath optimization mode. */
   public ReducedClasspathMode reducedClasspathMode() {
     return reducedClasspathMode;

--- a/javatests/com/google/turbine/options/TurbineOptionsTest.java
+++ b/javatests/com/google/turbine/options/TurbineOptionsTest.java
@@ -97,7 +97,6 @@ public class TurbineOptionsTest {
     assertThat(options.targetLabel()).hasValue("//java/com/google/test");
     assertThat(options.injectingRuleKind()).hasValue("foo_library");
     assertThat(options.reducedClasspathMode()).isEqualTo(ReducedClasspathMode.NONE);
-    assertThat(options.shouldReduceClassPath()).isFalse();
   }
 
   @Test
@@ -325,23 +324,6 @@ public class TurbineOptionsTest {
                 ImmutableList.of("--gensrc_output", "gensrc.jar", "--profile", "turbine.prof")));
     assertThat(options.gensrcOutput()).hasValue("gensrc.jar");
     assertThat(options.profile()).hasValue("turbine.prof");
-  }
-
-  @Test
-  public void shouldReduceClasspath() throws Exception {
-    {
-      TurbineOptions options =
-          TurbineOptionsParser.parse(
-              Iterables.concat(BASE_ARGS, ImmutableList.of("--reduce_classpath")));
-      assertThat(options.shouldReduceClassPath()).isTrue();
-    }
-
-    {
-      TurbineOptions options =
-          TurbineOptionsParser.parse(
-              Iterables.concat(BASE_ARGS, ImmutableList.of("--noreduce_classpath")));
-      assertThat(options.shouldReduceClassPath()).isFalse();
-    }
   }
 
   @Test


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove deprecated shouldReduceClassPath getter

it has been made obsolete by 'reducedClasspathMode'.

9815db03339275727455a10766f15efcd2a115ae