### PR TITLE
Moe Sync

### DIFF
--- a/java/com/google/turbine/parse/ConstExpressionParser.java
+++ b/java/com/google/turbine/parse/ConstExpressionParser.java
@@ -96,7 +96,7 @@ public class ConstExpressionParser {
     }
   }
 
-  private Tree.Expression primary(boolean negate) {
+  private Tree.@Nullable Expression primary(boolean negate) {
     switch (token) {
       case INT_LITERAL:
         return finishLiteral(TurbineConstantTypeKind.INT, negate);
@@ -563,12 +563,16 @@ public class ConstExpressionParser {
     return new Tree.TypeCast(position, new Tree.PrimTy(position, ImmutableList.of(), ty), rhs);
   }
 
-  private Tree.AnnoExpr annotation() {
+  private Tree.@Nullable AnnoExpr annotation() {
     if (token != Token.AT) {
       throw new AssertionError();
     }
     eat();
-    ImmutableList<Ident> name = ((Tree.ConstVarName) qualIdent()).name();
+    Tree.ConstVarName constVarName = (Tree.ConstVarName) qualIdent();
+    if (constVarName == null) {
+      return null;
+    }
+    ImmutableList<Ident> name = constVarName.name();
     ImmutableList.Builder<Tree.Expression> args = ImmutableList.builder();
     if (token == Token.LPAREN) {
       eat();

--- a/java/com/google/turbine/parse/Parser.java
+++ b/java/com/google/turbine/parse/Parser.java
@@ -25,7 +25,6 @@ import static com.google.turbine.tree.TurbineModifier.PROTECTED;
 import static com.google.turbine.tree.TurbineModifier.PUBLIC;
 import static com.google.turbine.tree.TurbineModifier.VARARGS;
 
-import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.CheckReturnValue;
@@ -1006,7 +1005,9 @@ public class Parser {
           break OUTER;
       }
     }
-    Verify.verify(typeAnnos.isEmpty());
+    if (!typeAnnos.isEmpty()) {
+      throw error(token);
+    }
     // the parameter name is `this` for receiver parameters, and a qualified this expression
     // for inner classes
     Ident name = identOrThis();

--- a/java/com/google/turbine/parse/Parser.java
+++ b/java/com/google/turbine/parse/Parser.java
@@ -943,9 +943,13 @@ public class Parser {
     return ty;
   }
 
-  private static Type extraDims(Type type, Deque<ImmutableList<Anno>> extra) {
+  private Type extraDims(Type type, Deque<ImmutableList<Anno>> extra) {
     if (extra.isEmpty()) {
       return type;
+    }
+    if (type == null) {
+      // trailing dims without a type, e.g. for a constructor declaration
+      throw error(token);
     }
     if (type.kind() == Kind.ARR_TY) {
       ArrTy arrTy = (ArrTy) type;

--- a/java/com/google/turbine/parse/StreamLexer.java
+++ b/java/com/google/turbine/parse/StreamLexer.java
@@ -238,7 +238,9 @@ public class StreamLexer implements Lexer {
           return identifier();
 
         case ASCII_SUB:
-          verify(reader.done());
+          if (!reader.done()) {
+            throw error(ErrorKind.UNEXPECTED_EOF);
+          }
           return Token.EOF;
 
         case '-':

--- a/java/com/google/turbine/parse/VariableInitializerParser.java
+++ b/java/com/google/turbine/parse/VariableInitializerParser.java
@@ -280,6 +280,9 @@ public class VariableInitializerParser {
     int lastType = -1;
     int lastComma = -1;
     for (int i = 0; i < many; i++) {
+      if (ltIndices.isEmpty()) {
+        throw error(ErrorKind.UNEXPECTED_TOKEN, ">");
+      }
       lastType = ltIndices.removeLast();
       lastComma = commaIndices.removeLast();
     }

--- a/javatests/com/google/turbine/parse/ParseErrorTest.java
+++ b/javatests/com/google/turbine/parse/ParseErrorTest.java
@@ -245,6 +245,23 @@ public class ParseErrorTest {
     }
   }
 
+  @Test
+  public void invalidAnnotation() {
+    String input = "@Foo(x =  @E [] x) class T {}";
+    try {
+      Parser.parse(input);
+      fail("expected parsing to fail");
+    } catch (TurbineError e) {
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo(
+              lines(
+                  "<>:1: error: invalid annotation argument", //
+                  "@Foo(x =  @E [] x) class T {}",
+                  "                ^"));
+    }
+  }
+
   private static String lines(String... lines) {
     return Joiner.on(System.lineSeparator()).join(lines);
   }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Don't crash parsing extra array dimensions on methods without a return type

java.lang.NullPointerException
	at com.google.turbine.parse.Parser.extraDims(Parser.java:950)
	at com.google.turbine.parse.Parser.extraDims(Parser.java:942)
	at com.google.turbine.parse.Parser.methodRest(Parser.java:872)
	at com.google.turbine.parse.Parser.classMember(Parser.java:699)
	at com.google.turbine.parse.Parser.classMembers(Parser.java:619)
	at com.google.turbine.parse.Parser.classDeclaration(Parser.java:524)
	at com.google.turbine.parse.Parser.compilationUnit(Parser.java:166)
	at com.google.turbine.parse.Parser.parse(Parser.java:87)
	at com.google.turbine.parse.Parser.parse(Parser.java:83)

459eb99a0a6c45308c5708be4993f47290fc6c00

-------

<p> Don't crash on orphaned type annotations on formal parameters

com.google.common.base.VerifyException
	at com.google.common.base.Verify.verify(Verify.java:100)
	at com.google.turbine.parse.Parser.formalParam(Parser.java:1009)
	at com.google.turbine.parse.Parser.formalParams(Parser.java:973)
	at com.google.turbine.parse.Parser.methodRest(Parser.java:869)
	at com.google.turbine.parse.Parser.memberRest(Parser.java:813)
	at com.google.turbine.parse.Parser.classMember(Parser.java:675)
	at com.google.turbine.parse.Parser.classMembers(Parser.java:619)
	at com.google.turbine.parse.Parser.classDeclaration(Parser.java:524)
	at com.google.turbine.parse.Parser.compilationUnit(Parser.java:166)
	at com.google.turbine.parse.Parser.parse(Parser.java:87)
	at com.google.turbine.parse.Parser.parse(Parser.java:83)

030ac88cb8053b867d96848752dd314d444f7917

-------

<p> Don't crash on unmatched angle brackets in variable initializers

java.util.NoSuchElementException
	at java.util.ArrayDeque.removeLast(ArrayDeque.java:295)
	at com.google.turbine.parse.VariableInitializerParser.dropBracks(VariableInitializerParser.java:283)
	at com.google.turbine.parse.VariableInitializerParser.parseInitializers(VariableInitializerParser.java:130)
	at com.google.turbine.parse.Parser.fieldRest(Parser.java:828)
	at com.google.turbine.parse.Parser.memberRest(Parser.java:810)
	at com.google.turbine.parse.Parser.classMember(Parser.java:712)
	at com.google.turbine.parse.Parser.classMembers(Parser.java:619)
	at com.google.turbine.parse.Parser.classDeclaration(Parser.java:524)
	at com.google.turbine.parse.Parser.compilationUnit(Parser.java:166)
	at com.google.turbine.parse.Parser.parse(Parser.java:87)
	at com.google.turbine.parse.Parser.parse(Parser.java:83)

35a546ff33e8219d201914ade90a2845758997fe

-------

<p> Don't crash on ill-formed annotations

java.lang.NullPointerException
	at com.google.turbine.parse.ConstExpressionParser.annotation(ConstExpressionParser.java:571)
	at com.google.turbine.parse.ConstExpressionParser.primary(ConstExpressionParser.java:161)
	at com.google.turbine.parse.ConstExpressionParser.expression(ConstExpressionParser.java:489)
	at com.google.turbine.parse.ConstExpressionParser.assign(ConstExpressionParser.java:531)
	at com.google.turbine.parse.ConstExpressionParser.expression(ConstExpressionParser.java:512)
	at com.google.turbine.parse.ConstExpressionParser.expression(ConstExpressionParser.java:493)
	at com.google.turbine.parse.ConstExpressionParser.expression(ConstExpressionParser.java:475)
	at com.google.turbine.parse.Parser.annotation(Parser.java:1364)
	at com.google.turbine.parse.Parser.maybeAnnos(Parser.java:788)
	at com.google.turbine.parse.Parser.extraDims(Parser.java:940)

6de52de42bc79817a9d9215b5c635c7f2e64f067

-------

<p> Don't crash if we see an ASCII_SUB before end-of-input is reached

com.google.common.base.VerifyException
	at com.google.common.base.Verify.verify(Verify.java:100)
	at com.google.turbine.parse.StreamLexer.next(StreamLexer.java:241)
	at com.google.turbine.parse.Parser.<init>(Parser.java:92)
	at com.google.turbine.parse.Parser.parse(Parser.java:87)
	at com.google.turbine.parse.Parser.parse(Parser.java:83)

ddd0689003055742e05642b633322c803cf57d3e