### PR TITLE
Moe Sync

### DIFF
--- a/java/com/google/turbine/binder/Processing.java
+++ b/java/com/google/turbine/binder/Processing.java
@@ -317,7 +317,8 @@ public class Processing {
   public static ProcessorInfo initializeProcessors(
       ImmutableList<String> javacopts,
       ImmutableList<String> processorPath,
-      ImmutableSet<String> processorNames)
+      ImmutableSet<String> processorNames,
+      ImmutableSet<String> builtinProcessors)
       throws MalformedURLException {
     ClassLoader processorLoader = null;
     ImmutableList.Builder<Processor> processors = ImmutableList.builder();
@@ -333,7 +334,12 @@ public class Processing {
                     if (name.startsWith("com.sun.source.")
                         || name.startsWith("com.sun.tools.")
                         || name.startsWith("com.google.common.collect.")
-                        || name.startsWith("com.google.common.base.")) {
+                        || name.startsWith("com.google.common.base.")
+                        || name.startsWith("com.google.common.graph.")
+                        || name.startsWith("com.google.devtools.build.buildjar.javac.statistics.")
+                        || name.startsWith("dagger.model.")
+                        || name.startsWith("dagger.spi.")
+                        || builtinProcessors.contains(name)) {
                       return Class.forName(name);
                     }
                     throw new ClassNotFoundException(name);

--- a/java/com/google/turbine/binder/lookup/ImportIndex.java
+++ b/java/com/google/turbine/binder/lookup/ImportIndex.java
@@ -142,7 +142,8 @@ public class ImportIndex implements ImportScope {
       TurbineLogWithSource log, TopLevelIndex cpi, ImportDecl i) {
     LookupResult base = cpi.scope().lookup(new LookupKey(i.type()));
     if (base == null) {
-      log.error(i.position(), ErrorKind.SYMBOL_NOT_FOUND, Joiner.on(".").join(i.type()));
+      log.error(
+          i.position(), ErrorKind.SYMBOL_NOT_FOUND, new ClassSymbol(Joiner.on("/").join(i.type())));
       return null;
     }
     return new ImportScope() {

--- a/java/com/google/turbine/main/Main.java
+++ b/java/com/google/turbine/main/Main.java
@@ -249,7 +249,8 @@ public class Main {
         Processing.initializeProcessors(
             /* javacopts= */ options.javacOpts(),
             /* processorPath= */ options.processorPath(),
-            /* processorNames= */ options.processors()),
+            /* processorNames= */ options.processors(),
+            /* builtinProcessors= */ options.builtinProcessors()),
         bootclasspath,
         /* moduleVersion=*/ Optional.empty());
   }

--- a/java/com/google/turbine/types/Canonicalize.java
+++ b/java/com/google/turbine/types/Canonicalize.java
@@ -290,6 +290,7 @@ public class Canonicalize {
         return instantiateWildTy(mapping, (WildTy) type);
       case PRIM_TY:
       case VOID_TY:
+      case ERROR_TY:
         return type;
       case CLASS_TY:
         return instantiateClassTy(mapping, (ClassTy) type);


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Load built-in annotation processors from turbine's classpath

d57a0db9983202b76b593d77eb4d4a0ecdee433b

-------

<p> Handle more ERROR_TYs in canonicalization pass

511c78fedd9aea7a639faa9eef9ff9d278179a0f

-------

<p> Use the annotation processor's classloader for annotation proxies

this matches javac's behaviour, and avoids classloader skew for
built-in processors.

6a883c9b5ec64fbc9a83d9b2ab0a1fc322d3e218

-------

<p> Log ClassSymbols instead of strings for SYMBOL_NOT_FOUND errors

ClassSymbols are useful for post-processing diagnostics

d873380db5fea251374d296ceb45b05c4ed9ee14

-------

<p> getAllElementsAnnotatedWith should support @Inherited

86744919041db9425b5984bf4ca5c2bb31c5c1d5