### PR TITLE
Moe Sync

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>com.google.truth.extensions</groupId>
       <artifactId>truth-java8-extension</artifactId>
-      <version>0.44</version>
+      <version>1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Emit manifests for srcjar jars

For compatibility with JavaBuilder, and to clean up manifest handling
for output jars in general.

Some tools that consume archives (e.g. unzip) don't like empty archives,
so emitting a manifest ensures the gensrc jar is never empty.

9a3a526db5238ed8690c8f6586ca99c668021fcd