### PR TITLE
MOE Sync 2019-11-13

### DIFF
--- a/java/com/google/turbine/binder/DisambiguateTypeAnnotations.java
+++ b/java/com/google/turbine/binder/DisambiguateTypeAnnotations.java
@@ -279,6 +279,9 @@ public class DisambiguateTypeAnnotations {
           elements.add(new TurbineAnnotationValue(element));
         }
         TypeBoundClass info = env.get(symbol);
+        if (info == null || info.annotationMetadata() == null) {
+          continue;
+        }
         ClassSymbol container = info.annotationMetadata().repeatable();
         if (container == null) {
           if (isKotlinRepeatable(info)) {

--- a/java/com/google/turbine/binder/Processing.java
+++ b/java/com/google/turbine/binder/Processing.java
@@ -288,7 +288,8 @@ public class Processing {
           addAnno(result, annoInfo, sym);
         }
       }
-      for (ClassSymbol inheritedAnno : inheritedAnnotations(info.superclass(), env)) {
+      for (ClassSymbol inheritedAnno :
+          inheritedAnnotations(new HashSet<>(), info.superclass(), env)) {
         result.put(inheritedAnno, sym);
       }
       for (TypeBoundClass.MethodInfo method : info.methods()) {
@@ -312,10 +313,10 @@ public class Processing {
 
   // TODO(cushon): consider memoizing this (or isAnnotationInherited) if they show up in profiles
   private static Set<ClassSymbol> inheritedAnnotations(
-      ClassSymbol sym, Env<ClassSymbol, TypeBoundClass> env) {
+      Set<ClassSymbol> seen, ClassSymbol sym, Env<ClassSymbol, TypeBoundClass> env) {
     ImmutableSet.Builder<ClassSymbol> result = ImmutableSet.builder();
     ClassSymbol curr = sym;
-    while (curr != null) {
+    while (curr != null && seen.add(curr)) {
       TypeBoundClass info = env.get(curr);
       if (info == null) {
         break;

--- a/javatests/com/google/turbine/binder/BinderErrorTest.java
+++ b/javatests/com/google/turbine/binder/BinderErrorTest.java
@@ -22,11 +22,19 @@ import static org.junit.Assert.fail;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.turbine.binder.Processing.ProcessorInfo;
 import com.google.turbine.diag.TurbineError;
 import com.google.turbine.parse.Parser;
 import com.google.turbine.tree.Tree.CompUnit;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -626,7 +634,22 @@ public class BinderErrorTest {
           "@NoSuch",
           "^",
         },
-      }
+      },
+      {
+        {
+          "public class Test {", //
+          "  @String @String int x;",
+          "}",
+        },
+        {
+          "<>:2: error: java.lang.String is not an annotation",
+          "  @String @String int x;",
+          "  ^",
+          "<>:2: error: java.lang.String is not an annotation",
+          "  @String @String int x;",
+          "          ^",
+        },
+      },
     };
     return Arrays.asList((Object[][]) testCases);
   }
@@ -645,6 +668,41 @@ public class BinderErrorTest {
       Binder.bind(
               ImmutableList.of(parseLines(source)),
               ClassPathBinder.bindClasspath(ImmutableList.of()),
+              TURBINE_BOOTCLASSPATH,
+              /* moduleVersion=*/ Optional.empty())
+          .units();
+      fail(Joiner.on('\n').join(source));
+    } catch (TurbineError e) {
+      assertThat(e).hasMessageThat().isEqualTo(lines(expected));
+    }
+  }
+
+  @SupportedAnnotationTypes("*")
+  static class HelloWorldProcessor extends AbstractProcessor {
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+      return SourceVersion.latestSupported();
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+      return false;
+    }
+  }
+
+  // exercise error reporting with annotation enabled, which should be identical
+  @Test
+  public void testWithProcessors() throws Exception {
+    try {
+      Binder.bind(
+              ImmutableList.of(parseLines(source)),
+              ClassPathBinder.bindClasspath(ImmutableList.of()),
+              ProcessorInfo.create(
+                  ImmutableList.of(new HelloWorldProcessor()),
+                  /* loader= */ getClass().getClassLoader(),
+                  /* options= */ ImmutableMap.of(),
+                  SourceVersion.latestSupported()),
               TURBINE_BOOTCLASSPATH,
               /* moduleVersion=*/ Optional.empty())
           .units();


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix annotation processing error reporting

including:
* an NPE in DisambiguateTypeAnnotations
* a loop in inherited annotation handling for cyclic hierarchies

and run the BinderError tests with annotation processing enabled, to
shake out processing-only error reporting bugs.

a5d4fe0d56c632f5b5311c0c2bb88eb7e2230712