### PR TITLE
MOE Sync 2019-11-13

### DIFF
--- a/java/com/google/turbine/binder/ConstEvaluator.java
+++ b/java/com/google/turbine/binder/ConstEvaluator.java
@@ -1007,6 +1007,9 @@ public strictfp class ConstEvaluator {
     }
     switch (ty.tyKind()) {
       case PRIM_TY:
+        if (!(value instanceof Const.Value)) {
+          throw error(tree.position(), ErrorKind.EXPRESSION_ERROR);
+        }
         return coerce((Const.Value) value, ((Type.PrimTy) ty).primkind());
       case CLASS_TY:
       case TY_VAR:

--- a/javatests/com/google/turbine/binder/BinderErrorTest.java
+++ b/javatests/com/google/turbine/binder/BinderErrorTest.java
@@ -650,6 +650,23 @@ public class BinderErrorTest {
           "          ^",
         },
       },
+      {
+        {
+          "@interface Anno {",
+          "  int value();",
+          "}",
+          "enum E {",
+          "  ONE",
+          "}",
+          "@Anno(value = E.ONE)",
+          "interface Test {}",
+        },
+        {
+          "<>:7: error: could not evaluate constant expression", //
+          "@Anno(value = E.ONE)",
+          "              ^",
+        },
+      },
     };
     return Arrays.asList((Object[][]) testCases);
   }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Don't crash on invalid annotation literals

where an enum constants appears for an element value that should be a
primitive.

84c83446e6c2ff4e0de9ec204e830e1be96b876c