### PR TITLE
MOE Sync 2020-01-13

### DIFF
--- a/java/com/google/turbine/main/Main.java
+++ b/java/com/google/turbine/main/Main.java
@@ -256,9 +256,6 @@ public class Main {
   }
 
   private static void usage(TurbineOptions options) {
-    if (options.sources().isEmpty() && options.sourceJars().isEmpty()) {
-      throw new UsageException("no sources were provided");
-    }
     if (options.help()) {
       throw new UsageException();
     }

--- a/javatests/com/google/turbine/main/MainTest.java
+++ b/javatests/com/google/turbine/main/MainTest.java
@@ -29,6 +29,7 @@ import com.google.common.io.ByteStreams;
 import com.google.common.io.MoreFiles;
 import com.google.turbine.diag.TurbineError;
 import com.google.turbine.options.TurbineOptions;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -259,6 +260,20 @@ public class MainTest {
       assertThat(expected)
           .hasMessageThat()
           .contains("at least one of --output, --gensrc_output, or --resource_output is required");
+    }
+  }
+
+  @Test
+  public void noSources() throws IOException {
+    // Compilations with no sources (or source jars) are accepted, and create empty for requested
+    // outputs. This is helpful for the Bazel integration, which allows java_library rules to be
+    // declared without sources.
+    File gensrc = temporaryFolder.newFile("gensrc.jar");
+    Main.compile(optionsWithBootclasspath().setGensrcOutput(gensrc.toString()).build());
+    try (JarFile jarFile = new JarFile(gensrc);
+        Stream<JarEntry> entries = jarFile.stream()) {
+      assertThat(entries.map(JarEntry::getName))
+          .containsExactly("META-INF/", "META-INF/MANIFEST.MF");
     }
   }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Allow --sources to be empty

and perform a no-op compilation, which produces empty jars for any requested outputs.

This is helpful for the Bazel integration, which allows java_library rules to
be declared without sources.

92b35f52c933ec84eac4048a8a8bedbc5ad7ab19