### PR TITLE
MOE Sync 2020-01-16

### DIFF
--- a/java/com/google/turbine/binder/Binder.java
+++ b/java/com/google/turbine/binder/Binder.java
@@ -64,7 +64,6 @@ import com.google.turbine.tree.Tree.CompUnit;
 import com.google.turbine.tree.Tree.ModDecl;
 import com.google.turbine.type.Type;
 import java.time.Duration;
-import java.util.List;
 import java.util.Optional;
 import javax.annotation.processing.Processor;
 
@@ -73,7 +72,7 @@ public class Binder {
 
   /** Binds symbols and types to the given compilation units. */
   public static BindingResult bind(
-      List<CompUnit> units,
+      ImmutableList<CompUnit> units,
       ClassPath classpath,
       ClassPath bootclasspath,
       Optional<String> moduleVersion) {
@@ -82,7 +81,7 @@ public class Binder {
 
   /** Binds symbols and types to the given compilation units. */
   public static BindingResult bind(
-      List<CompUnit> units,
+      ImmutableList<CompUnit> units,
       ClassPath classpath,
       ProcessorInfo processorInfo,
       ClassPath bootclasspath,
@@ -108,7 +107,7 @@ public class Binder {
 
   static BindingResult bind(
       TurbineLog log,
-      List<CompUnit> units,
+      ImmutableList<CompUnit> units,
       ImmutableMap<String, SourceFile> generatedSources,
       ImmutableMap<String, byte[]> generatedClasses,
       ClassPath classpath,

--- a/java/com/google/turbine/binder/Binder.java
+++ b/java/com/google/turbine/binder/Binder.java
@@ -97,7 +97,7 @@ public class Binder {
             classpath,
             bootclasspath,
             moduleVersion);
-    if (!processorInfo.processors().isEmpty()) {
+    if (!processorInfo.processors().isEmpty() && !units.isEmpty()) {
       br =
           Processing.process(
               log, units, classpath, processorInfo, bootclasspath, br, moduleVersion);

--- a/java/com/google/turbine/binder/Processing.java
+++ b/java/com/google/turbine/binder/Processing.java
@@ -78,7 +78,7 @@ public class Processing {
 
   static BindingResult process(
       TurbineLog log,
-      final List<CompUnit> initialSources,
+      final ImmutableList<CompUnit> initialSources,
       final ClassPath classpath,
       ProcessorInfo processorInfo,
       ClassPath bootclasspath,
@@ -147,7 +147,8 @@ public class Processing {
 
     Set<ClassSymbol> allSymbols = new HashSet<>();
 
-    List<CompUnit> units = new ArrayList<>(initialSources);
+    ImmutableList.Builder<CompUnit> units =
+        ImmutableList.<CompUnit>builder().addAll(initialSources);
 
     Set<Processor> toRun = new LinkedHashSet<>();
 
@@ -202,7 +203,7 @@ public class Processing {
       result =
           Binder.bind(
               log,
-              units,
+              units.build(),
               filer.generatedSources(),
               filer.generatedClasses(),
               classpath,
@@ -242,7 +243,7 @@ public class Processing {
       result =
           Binder.bind(
               log,
-              units,
+              units.build(),
               filer.generatedSources(),
               filer.generatedClasses(),
               classpath,

--- a/java/com/google/turbine/binder/Processing.java
+++ b/java/com/google/turbine/binder/Processing.java
@@ -383,6 +383,7 @@ public class Processing {
                         || name.startsWith("com.google.devtools.build.buildjar.javac.statistics.")
                         || name.startsWith("dagger.model.")
                         || name.startsWith("dagger.spi.")
+                        || name.equals("com.google.turbine.processing.TurbineProcessingEnvironment")
                         || builtinProcessors.contains(name)) {
                       return Class.forName(name);
                     }

--- a/java/com/google/turbine/main/Main.java
+++ b/java/com/google/turbine/main/Main.java
@@ -353,9 +353,7 @@ public class Main {
         BufferedOutputStream bos = new BufferedOutputStream(os, BUFFER_SIZE);
         JarOutputStream jos = new JarOutputStream(bos)) {
       for (Map.Entry<String, byte[]> resource : generatedResources.entrySet()) {
-        if (!resource.getKey().endsWith(".class")) {
-          addEntry(jos, resource.getKey(), resource.getValue());
-        }
+        addEntry(jos, resource.getKey(), resource.getValue());
       }
     }
   }

--- a/javatests/com/google/turbine/binder/BinderTest.java
+++ b/javatests/com/google/turbine/binder/BinderTest.java
@@ -36,8 +36,6 @@ import com.google.turbine.tree.Tree;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.jar.JarEntry;
@@ -55,22 +53,21 @@ public class BinderTest {
 
   @Test
   public void hello() throws Exception {
-    List<Tree.CompUnit> units = new ArrayList<>();
-    units.add(
-        parseLines(
-            "package a;", //
-            "public class A {",
-            "  public class Inner1 extends b.B {",
-            "  }",
-            "  public class Inner2 extends A.Inner1 {",
-            "  }",
-            "}"));
-    units.add(
-        parseLines(
-            "package b;", //
-            "import a.A;",
-            "public class B extends A {",
-            "}"));
+    ImmutableList<Tree.CompUnit> units =
+        ImmutableList.of(
+            parseLines(
+                "package a;", //
+                "public class A {",
+                "  public class Inner1 extends b.B {",
+                "  }",
+                "  public class Inner2 extends A.Inner1 {",
+                "  }",
+                "}"),
+            parseLines(
+                "package b;", //
+                "import a.A;",
+                "public class B extends A {",
+                "}"));
 
     ImmutableMap<ClassSymbol, SourceTypeBoundClass> bound =
         Binder.bind(
@@ -103,20 +100,19 @@ public class BinderTest {
 
   @Test
   public void interfaces() throws Exception {
-    List<Tree.CompUnit> units = new ArrayList<>();
-    units.add(
-        parseLines(
-            "package com.i;", //
-            "public interface I {",
-            "  public class IInner {",
-            "  }",
-            "}"));
-    units.add(
-        parseLines(
-            "package b;", //
-            "class B implements com.i.I {",
-            "  class BInner extends IInner {}",
-            "}"));
+    ImmutableList<Tree.CompUnit> units =
+        ImmutableList.of(
+            parseLines(
+                "package com.i;", //
+                "public interface I {",
+                "  public class IInner {",
+                "  }",
+                "}"),
+            parseLines(
+                "package b;", //
+                "class B implements com.i.I {",
+                "  class BInner extends IInner {}",
+                "}"));
 
     ImmutableMap<ClassSymbol, SourceTypeBoundClass> bound =
         Binder.bind(
@@ -143,20 +139,19 @@ public class BinderTest {
 
   @Test
   public void imports() throws Exception {
-    List<Tree.CompUnit> units = new ArrayList<>();
-    units.add(
-        parseLines(
-            "package com.test;", //
-            "public class Test {",
-            "  public static class Inner {}",
-            "}"));
-    units.add(
-        parseLines(
-            "package other;", //
-            "import com.test.Test.Inner;",
-            "import no.such.Class;", // imports are resolved lazily on-demand
-            "public class Foo extends Inner {",
-            "}"));
+    ImmutableList<Tree.CompUnit> units =
+        ImmutableList.of(
+            parseLines(
+                "package com.test;", //
+                "public class Test {",
+                "  public static class Inner {}",
+                "}"),
+            parseLines(
+                "package other;", //
+                "import com.test.Test.Inner;",
+                "import no.such.Class;", // imports are resolved lazily on-demand
+                "public class Foo extends Inner {",
+                "}"));
 
     ImmutableMap<ClassSymbol, SourceTypeBoundClass> bound =
         Binder.bind(
@@ -172,21 +167,20 @@ public class BinderTest {
 
   @Test
   public void cycle() throws Exception {
-    List<Tree.CompUnit> units = new ArrayList<>();
-    units.add(
-        parseLines(
-            "package a;", //
-            "import b.B;",
-            "public class A extends B.Inner {",
-            "  class Inner {}",
-            "}"));
-    units.add(
-        parseLines(
-            "package b;", //
-            "import a.A;",
-            "public class B extends A.Inner {",
-            "  class Inner {}",
-            "}"));
+    ImmutableList<Tree.CompUnit> units =
+        ImmutableList.of(
+            parseLines(
+                "package a;", //
+                "import b.B;",
+                "public class A extends B.Inner {",
+                "  class Inner {}",
+                "}"),
+            parseLines(
+                "package b;", //
+                "import a.A;",
+                "public class B extends A.Inner {",
+                "  class Inner {}",
+                "}"));
 
     try {
       Binder.bind(
@@ -202,12 +196,12 @@ public class BinderTest {
 
   @Test
   public void annotationDeclaration() throws Exception {
-    List<Tree.CompUnit> units = new ArrayList<>();
-    units.add(
-        parseLines(
-            "package com.test;", //
-            "public @interface Annotation {",
-            "}"));
+    ImmutableList<Tree.CompUnit> units =
+        ImmutableList.of(
+            parseLines(
+                "package com.test;", //
+                "public @interface Annotation {",
+                "}"));
 
     ImmutableMap<ClassSymbol, SourceTypeBoundClass> bound =
         Binder.bind(
@@ -230,13 +224,13 @@ public class BinderTest {
 
   @Test
   public void helloBytecode() throws Exception {
-    List<Tree.CompUnit> units = new ArrayList<>();
-    units.add(
-        parseLines(
-            "package a;", //
-            "import java.util.Map.Entry;",
-            "public class A implements Entry {",
-            "}"));
+    ImmutableList<Tree.CompUnit> units =
+        ImmutableList.of(
+            parseLines(
+                "package a;", //
+                "import java.util.Map.Entry;",
+                "public class A implements Entry {",
+                "}"));
 
     ImmutableMap<ClassSymbol, SourceTypeBoundClass> bound =
         Binder.bind(
@@ -268,15 +262,15 @@ public class BinderTest {
       jos.write(lib.get("B"));
     }
 
-    List<Tree.CompUnit> units = new ArrayList<>();
-    units.add(
-        parseLines(
-            "import java.lang.annotation.Target;",
-            "import java.lang.annotation.ElementType;",
-            "public class C implements B {",
-            "  @Target(ElementType.TYPE_USE)",
-            "  @interface A {};",
-            "}"));
+    ImmutableList<Tree.CompUnit> units =
+        ImmutableList.of(
+            parseLines(
+                "import java.lang.annotation.Target;",
+                "import java.lang.annotation.ElementType;",
+                "public class C implements B {",
+                "  @Target(ElementType.TYPE_USE)",
+                "  @interface A {};",
+                "}"));
 
     ImmutableMap<ClassSymbol, SourceTypeBoundClass> bound =
         Binder.bind(
@@ -294,13 +288,13 @@ public class BinderTest {
   // (Error reporting is deferred to javac.)
   @Test
   public void invalidConst() throws Exception {
-    List<Tree.CompUnit> units = new ArrayList<>();
-    units.add(
-        parseLines(
-            "package a;", //
-            "public class A {",
-            "  public static final boolean b = true == 42;",
-            "}"));
+    ImmutableList<Tree.CompUnit> units =
+        ImmutableList.of(
+            parseLines(
+                "package a;", //
+                "public class A {",
+                "  public static final boolean b = true == 42;",
+                "}"));
 
     ImmutableMap<ClassSymbol, SourceTypeBoundClass> bound =
         Binder.bind(

--- a/javatests/com/google/turbine/deps/DependenciesTest.java
+++ b/javatests/com/google/turbine/deps/DependenciesTest.java
@@ -39,7 +39,6 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -87,7 +86,7 @@ public class DependenciesTest {
 
   static class DepsBuilder {
     List<Path> classpath;
-    List<CompUnit> units = new ArrayList<>();
+    ImmutableList.Builder<CompUnit> units = ImmutableList.builder();
 
     DepsBuilder setClasspath(Path... classpath) {
       this.classpath = ImmutableList.copyOf(classpath);
@@ -102,7 +101,7 @@ public class DependenciesTest {
     DepsProto.Dependencies run() throws IOException {
       BindingResult bound =
           Binder.bind(
-              units,
+              units.build(),
               ClassPathBinder.bindClasspath(classpath),
               TestClassPaths.TURBINE_BOOTCLASSPATH,
               /* moduleVersion=*/ Optional.empty());

--- a/javatests/com/google/turbine/lower/IntegrationTestSupport.java
+++ b/javatests/com/google/turbine/lower/IntegrationTestSupport.java
@@ -16,6 +16,7 @@
 
 package com.google.turbine.lower;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.turbine.testing.TestClassPaths.TURBINE_BOOTCLASSPATH;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.joining;
@@ -455,11 +456,11 @@ public class IntegrationTestSupport {
       ClassPath bootClassPath,
       Optional<String> moduleVersion)
       throws IOException {
-    List<CompUnit> units =
+    ImmutableList<CompUnit> units =
         input.entrySet().stream()
             .map(e -> new SourceFile(e.getKey(), e.getValue()))
             .map(Parser::parse)
-            .collect(toList());
+            .collect(toImmutableList());
 
     return Binder.bind(
         units, ClassPathBinder.bindClasspath(classpath), bootClassPath, moduleVersion);

--- a/javatests/com/google/turbine/processing/TurbineAnnotationProxyTest.java
+++ b/javatests/com/google/turbine/processing/TurbineAnnotationProxyTest.java
@@ -18,7 +18,6 @@ package com.google.turbine.processing;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
-import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.fail;
 
 import com.google.common.base.Joiner;
@@ -49,7 +48,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
@@ -138,11 +136,11 @@ public class TurbineAnnotationProxyTest {
                     "class Test extends Super {}",
                     ""));
 
-    List<CompUnit> units =
+    ImmutableList<CompUnit> units =
         input.sources.entrySet().stream()
             .map(e -> new SourceFile(e.getKey(), e.getValue()))
             .map(Parser::parse)
-            .collect(toList());
+            .collect(toImmutableList());
 
     Binder.BindingResult bound =
         Binder.bind(

--- a/javatests/com/google/turbine/processing/TurbineElementsGetAllMembersTest.java
+++ b/javatests/com/google/turbine/processing/TurbineElementsGetAllMembersTest.java
@@ -19,7 +19,6 @@ package com.google.turbine.processing;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toList;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
@@ -260,11 +259,11 @@ public class TurbineElementsGetAllMembersTest {
     List<? extends Element> javacMembers =
         javacElements.getAllMembers(requireNonNull(javacElements.getTypeElement("Test")));
 
-    List<CompUnit> units =
+    ImmutableList<CompUnit> units =
         input.sources.entrySet().stream()
             .map(e -> new SourceFile(e.getKey(), e.getValue()))
             .map(Parser::parse)
-            .collect(toList());
+            .collect(toImmutableList());
 
     Binder.BindingResult bound =
         Binder.bind(


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Allow sources to be empty with annotation processing enabled

948e786cba9c3212c79fac18d6606241d05ccf71

-------

<p> Make a list immutable

RELNOTES: N?A

f3268b1be3beec1a64f1c20ee880e8c40c3bd59c

-------

<p> Allow annotation processors to load TurbineProcessingEnvironment

f260cba6dfc2f4689a5d436417eb00f61b9b2860

-------

<p> Include .class resources in --resource_output

This was an oversight in a previous change When using turbine as an annotation
processing tool, and .class files generated directly by annotation processors
need to be saved separately and included in the final output (similar to non-.class
resources).

42da89f1f2519b31d3d18303b6c4c5cead8baeac