### PR TITLE
MOE Sync 2020-02-28

### DIFF
--- a/java/com/google/turbine/diag/TurbineError.java
+++ b/java/com/google/turbine/diag/TurbineError.java
@@ -49,6 +49,7 @@ public class TurbineError extends Error {
     NONREPEATABLE_ANNOTATION("%s is not @Repeatable"),
     DUPLICATE_DECLARATION("duplicate declaration of %s"),
     BAD_MODULE_INFO("unexpected declaration found in module-info"),
+    UNCLOSED_COMMENT("unclosed comment"),
     PROC("%s");
 
     private final String message;

--- a/java/com/google/turbine/parse/StreamLexer.java
+++ b/java/com/google/turbine/parse/StreamLexer.java
@@ -162,9 +162,11 @@ public class StreamLexer implements Lexer {
                       break;
                     case ASCII_SUB:
                       if (reader.done()) {
-                        return Token.EOF;
+                        throw TurbineError.format(
+                            reader.source(), position, ErrorKind.UNCLOSED_COMMENT);
                       }
                       eat();
+                      sawStar = false;
                       break;
                     default:
                       eat();

--- a/javatests/com/google/turbine/parse/LexerTest.java
+++ b/javatests/com/google/turbine/parse/LexerTest.java
@@ -40,12 +40,6 @@ public class LexerTest {
   }
 
   @Test
-  public void unterminated() {
-    assertThat(lex("/* foo")).containsExactly("EOF");
-    assertThat(lex("\" foo")).containsExactly("EOF");
-  }
-
-  @Test
   public void boolLiteral() {
     lexerComparisonTest("0b0101__01010");
     assertThat(lex("1 + 0b1000100101"))

--- a/javatests/com/google/turbine/parse/ParseErrorTest.java
+++ b/javatests/com/google/turbine/parse/ParseErrorTest.java
@@ -262,6 +262,23 @@ public class ParseErrorTest {
     }
   }
 
+  @Test
+  public void unclosedComment() {
+    String input = "/** *\u001a/ class Test {}";
+    try {
+      Parser.parse(input);
+      fail("expected parsing to fail");
+    } catch (TurbineError e) {
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo(
+              lines(
+                  "<>:1: error: unclosed comment", //
+                  "/** *\u001a/ class Test {}",
+                  "^"));
+    }
+  }
+
   private static String lines(String... lines) {
     return Joiner.on(System.lineSeparator()).join(lines);
   }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix a javadoc parsing bug, and emit errors for unclosed block comments

previously we were treating `*<ASCII SUB>/` as a valid javadoc
comment ending.

9a6987bb930355d9b7bf53eac74eb2e1332037f2