### PR TITLE
MOE Sync 2020-03-26

### DIFF
--- a/java/com/google/turbine/diag/TurbineError.java
+++ b/java/com/google/turbine/diag/TurbineError.java
@@ -44,6 +44,7 @@ public class TurbineError extends Error {
     INVALID_ANNOTATION_ARGUMENT("invalid annotation argument"),
     CANNOT_RESOLVE("could not resolve %s"),
     EXPRESSION_ERROR("could not evaluate constant expression"),
+    OPERAND_TYPE("bad operand type %s"),
     CYCLIC_HIERARCHY("cycle in class hierarchy: %s"),
     NOT_AN_ANNOTATION("%s is not an annotation"),
     NONREPEATABLE_ANNOTATION("%s is not @Repeatable"),

--- a/javatests/com/google/turbine/binder/BinderErrorTest.java
+++ b/javatests/com/google/turbine/binder/BinderErrorTest.java
@@ -688,6 +688,18 @@ public class BinderErrorTest {
           "                   ^",
         },
       },
+      {
+        {
+          "class T {", //
+          "  static final String s = \"a\" + + \"b\";",
+          "}",
+        },
+        {
+          "<>:2: error: bad operand type String",
+          "  static final String s = \"a\" + + \"b\";",
+          "                                     ^",
+        },
+      },
     };
     return Arrays.asList((Object[][]) testCases);
   }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Improve error reporting for constant expressions

including constant field initializers, and annotations.

Previously we were crashing e.g. on bogus infix expressions like
`"a" + + "b"`.

afa8829b69c58ac89ea97f9f1d154ed420f50248