### PR TITLE
Update native-maven-plugin to 0.9.23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <protobuf.version>3.19.2</protobuf.version>
     <grpc.version>1.43.2</grpc.version>
-    <native.maven.plugin.version>0.9.11</native.maven.plugin.version>
+    <native.maven.plugin.version>0.9.23</native.maven.plugin.version>
   </properties>
 
   <organization>


### PR DESCRIPTION
Fixes the following crash:

```
[ERROR] Failed to execute goal org.graalvm.buildtools:native-maven-plugin:0.9.11:test (test-native) on project turbine: Execution test-native of goal org.graalvm.buildtools:native-maven-plugin:0.9.11:test failed: A required class was missing while executing org.graalvm.buildtools:native-maven-plugin:0.9.11:test: org/graalvm/nativeimage/hosted/Feature
[ERROR] -----------------------------------------------------
[ERROR] realm =    extension>org.graalvm.buildtools:native-maven-plugin:0.9.11
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
[ERROR] urls[0] = file:/home/fhenneke/.m2/repository/org/graalvm/buildtools/native-maven-plugin/0.9.11/native-maven-plugin-0.9.11.jar
[ERROR] urls[1] = file:/home/fhenneke/.m2/repository/org/graalvm/buildtools/junit-platform-native/0.9.11/junit-platform-native-0.9.11.jar
[ERROR] urls[2] = file:/home/fhenneke/.m2/repository/org/junit/platform/junit-platform-console/1.8.1/junit-platform-console-1.8.1.jar
[ERROR] urls[3] = file:/home/fhenneke/.m2/repository/org/junit/platform/junit-platform-reporting/1.8.1/junit-platform-reporting-1.8.1.jar
[ERROR] urls[4] = file:/home/fhenneke/.m2/repository/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar
[ERROR] urls[5] = file:/home/fhenneke/.m2/repository/org/junit/platform/junit-platform-launcher/1.8.1/junit-platform-launcher-1.8.1.jar
[ERROR] urls[6] = file:/home/fhenneke/.m2/repository/org/junit/platform/junit-platform-engine/1.8.1/junit-platform-engine-1.8.1.jar
[ERROR] urls[7] = file:/home/fhenneke/.m2/repository/org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar
[ERROR] urls[8] = file:/home/fhenneke/.m2/repository/org/junit/platform/junit-platform-commons/1.8.1/junit-platform-commons-1.8.1.jar
[ERROR] urls[9] = file:/home/fhenneke/.m2/repository/org/junit/jupiter/junit-jupiter/5.8.1/junit-jupiter-5.8.1.jar
[ERROR] urls[10] = file:/home/fhenneke/.m2/repository/org/junit/jupiter/junit-jupiter-api/5.8.1/junit-jupiter-api-5.8.1.jar
[ERROR] urls[11] = file:/home/fhenneke/.m2/repository/org/junit/jupiter/junit-jupiter-params/5.8.1/junit-jupiter-params-5.8.1.jar
[ERROR] urls[12] = file:/home/fhenneke/.m2/repository/org/junit/jupiter/junit-jupiter-engine/5.8.1/junit-jupiter-engine-5.8.1.jar
[ERROR] urls[13] = file:/home/fhenneke/.m2/repository/org/graalvm/buildtools/utils/0.9.11/utils-0.9.11.jar
[ERROR] urls[14] = file:/home/fhenneke/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.12.4/jackson-databind-2.12.4.jar
[ERROR] urls[15] = file:/home/fhenneke/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.12.4/jackson-annotations-2.12.4.jar
[ERROR] urls[16] = file:/home/fhenneke/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.12.4/jackson-core-2.12.4.jar
[ERROR] urls[17] = file:/home/fhenneke/.m2/repository/org/codehaus/plexus/plexus-utils/1.1/plexus-utils-1.1.jar
[ERROR] Number of foreign imports: 1
[ERROR] import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
[ERROR] 
[ERROR] -----------------------------------------------------
[ERROR] : org.graalvm.nativeimage.hosted.Feature
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginContainerException
```