### PR TITLE
Allow path to `ct.sym` to be specified via a system property

### DIFF
--- a/java/com/google/turbine/binder/CtSymClassBinder.java
+++ b/java/com/google/turbine/binder/CtSymClassBinder.java
@@ -48,11 +48,20 @@ public final class CtSymClassBinder {
   private static final int FEATURE_VERSION = Runtime.version().feature();
 
   public static @Nullable ClassPath bind(int version) throws IOException {
-    String javaHome = JAVA_HOME.value();
-    requireNonNull(javaHome, "attempted to use --release, but JAVA_HOME is not set");
-    Path ctSym = Paths.get(javaHome).resolve("lib/ct.sym");
-    if (!Files.exists(ctSym)) {
-      throw new IllegalStateException("lib/ct.sym does not exist in " + javaHome);
+    Path ctSym;
+    String explicitCtSymPath = System.getProperty("turbine.ctSymPath");
+    if (explicitCtSymPath == null) {
+      String javaHome = JAVA_HOME.value();
+      requireNonNull(javaHome, "attempted to use --release, but JAVA_HOME is not set");
+      ctSym = Paths.get(javaHome).resolve("lib/ct.sym");
+      if (!Files.exists(ctSym)) {
+        throw new IllegalStateException("lib/ct.sym does not exist in " + javaHome);
+      }
+    } else {
+      ctSym = Paths.get(explicitCtSymPath);
+      if (!Files.exists(ctSym)) {
+        throw new IllegalStateException("ct.sym does not exist at " + ctSym);
+      }
     }
     Map<ClassSymbol, BytecodeBoundClass> map = new HashMap<>();
     Map<ModuleSymbol, ModuleInfo> modules = new HashMap<>();


### PR DESCRIPTION
When turbine is compiled into a native image, no JAVA_HOME will be available at runtime and the `java.home` system property won't be set. To still provide support for `--release` in that situation, the new `turbine.ctSymPath` system property can be set to give turbine the required access to `ct.sym`.

Work towards https://github.com/bazelbuild/stardoc/issues/195#issuecomment-1821286258