### PR TITLE
Check ct.sym first before falling back to jrt

### DIFF
--- a/java/com/google/turbine/main/Main.java
+++ b/java/com/google/turbine/main/Main.java
@@ -301,16 +301,16 @@ public final class Main {
     }
 
     if (release.isPresent()) {
-      if (release.getAsInt() == Integer.parseInt(JAVA_SPECIFICATION_VERSION.value())) {
+      // Search ct.sym for a matching release
+      ClassPath bootclasspath = CtSymClassBinder.bind(release.getAsInt());
+      if (bootclasspath != null) {
+        return bootclasspath;
+      } else if (release.getAsInt() == Integer.parseInt(JAVA_SPECIFICATION_VERSION.value())) {
         // if --release matches the host JDK, use its jimage instead of ct.sym
         return JimageClassBinder.bindDefault();
-      }
-      // ... otherwise, search ct.sym for a matching release
-      ClassPath bootclasspath = CtSymClassBinder.bind(release.getAsInt());
-      if (bootclasspath == null) {
+      } else {
         throw new UsageException("not a supported release: " + release);
       }
-      return bootclasspath;
     }
 
     if (options.system().isPresent()) {


### PR DESCRIPTION
Since Turbine is used via a GraalVM native image in Bazel, jrt is not enabled, so looking up the bootclasspath that way doesn't work.

As of Java 22, ct.sym contains signatures for all supported JDKs, so there is no need to look in jrt.

Partial fix for https://github.com/bazelbuild/bazel/issues/21895