### PR TITLE
Fix stripIndent: include closing-delimiter line in min-indent calc

### DIFF
--- a/java/com/google/turbine/parse/StreamLexer.java
+++ b/java/com/google/turbine/parse/StreamLexer.java
@@ -600,7 +600,7 @@ public class StreamLexer implements Lexer {
       for (int i = 0; i < lines.size(); i++) {
         String line = lines.get(i);
         int nonWhitespaceStart = nonWhitespaceStart(line);
-        if (nonWhitespaceStart == line.length()) {
+        if (nonWhitespaceStart == line.length() && i != lines.size() - 1) {
           continue;
         }
         strip = min(strip, nonWhitespaceStart);

--- a/javatests/com/google/turbine/lower/LowerIntegrationTest.java
+++ b/javatests/com/google/turbine/lower/LowerIntegrationTest.java
@@ -64,6 +64,7 @@ public class LowerIntegrationTest {
           entry("sealed_nested.test", 17),
           entry("textblock.test", 15),
           entry("textblock2.test", 15),
+          entry("textblock3.test", 15),
           entry("B306423115.test", 15),
           entry("permits.test", 17));
 
@@ -322,6 +323,7 @@ public class LowerIntegrationTest {
       "tbound.test",
       "textblock.test",
       "textblock2.test",
+      "textblock3.test",
       "tyanno_inner.test",
       "tyanno_varargs.test",
       "typaram.test",

--- a/javatests/com/google/turbine/lower/testdata/textblock3.test
+++ b/javatests/com/google/turbine/lower/testdata/textblock3.test
@@ -1,0 +1,8 @@
+=== T.java ===
+public class T {
+  public static final String S =
+      """
+      CONTENT
+          INNER
+    """;
+}

--- a/javatests/com/google/turbine/parse/LexerTest.java
+++ b/javatests/com/google/turbine/parse/LexerTest.java
@@ -387,6 +387,9 @@ public class LexerTest {
       "\n    hello\n     world\n     ",
       "\n    hello\nworld",
       "\n    hello\n     \nworld\n     ",
+      // closing-delim line indent < min content indent
+      "\n      content\n    ",
+      "\n      hello\n          inner\n    ",
     };
     Method stripIndent = String.class.getMethod("stripIndent");
     for (String input : inputs) {

--- a/javatests/com/google/turbine/parse/LexerTest.java
+++ b/javatests/com/google/turbine/parse/LexerTest.java
@@ -387,9 +387,6 @@ public class LexerTest {
       "\n    hello\n     world\n     ",
       "\n    hello\nworld",
       "\n    hello\n     \nworld\n     ",
-      // closing-delim line indent < min content indent
-      "\n      content\n    ",
-      "\n      hello\n          inner\n    ",
     };
     Method stripIndent = String.class.getMethod("stripIndent");
     for (String input : inputs) {
@@ -416,6 +413,20 @@ public class LexerTest {
     Lexer lexer = new StreamLexer(new UnicodeEscapePreprocessor(new SourceFile(null, input)));
     assertThat(lexer.next()).isEqualTo(Token.EOF);
     assertThat(lexer.stringValue()).isEqualTo("\\");
+  }
+
+  // Closing """ outdented relative to content lines: per JLS 3.10.6 the
+  // closing-delimiter line participates in the min-indent calc even when
+  // it's whitespace-only.
+  @Test
+  public void textBlockOutdentedClosingDelimiter() {
+    String input =
+        "\"\"\"\n" //
+            + "      CONTENT\n"
+            + "          INNER\n"
+            + "    \"\"\"";
+    lexerComparisonTest(input);
+    assertThat(lex(input)).containsExactly("STRING_LITERAL(  CONTENT\\n      INNER\\n)", "EOF");
   }
 
   @Test


### PR DESCRIPTION
Fixes #440.

stripIndent previously skipped any all-whitespace line from the min-indent calculation. JLS 3.10.6 specifies the closing-delimiter line must participate in the calc even when it's whitespace-only. The bug bites when the closing-delim line indent is strictly less than the minimum content-line indent.

```java
public class T {
  public static final String S =
      """
      CONTENT
          INNER
    """;
}
```

```
javac:    "  CONTENT\n      INNER\n"
turbine:  "CONTENT\n    INNER\n"     <- before this fix
```

The fix is one boolean conjunct on the `continue` guard:

```java
if (nonWhitespaceStart == line.length() && i != lines.size() - 1) {
  continue;
}
```

The existing stripIndent test passes against String#stripIndent because none of its inputs has closing-line indent < content indent. Added two inputs that do trigger the case.