### PR TITLE
Remove overridden methods from getAllMembers results

### DIFF
--- a/java/com/google/turbine/processing/TurbineElements.java
+++ b/java/com/google/turbine/processing/TurbineElements.java
@@ -41,6 +41,7 @@ import java.io.PrintWriter;
 import java.io.Writer;
 import java.lang.reflect.Proxy;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -197,8 +198,10 @@ public class TurbineElements implements Elements {
     Multimap<String, TurbineExecutableElement> methods =
         MultimapBuilder.linkedHashKeys().linkedHashSetValues().build();
 
-    // collect all members of each transitive supertype of the input
-    ImmutableList.Builder<Element> results = ImmutableList.builder();
+    // collect all members of each transitive supertype of the input; a LinkedHashSet preserves
+    // encounter order while allowing overridden methods to be removed once a subtype's override is
+    // seen (a supertype may be visited before the subtype that overrides its methods).
+    LinkedHashSet<Element> results = new LinkedHashSet<>();
     for (ClassSymbol superType : factory.cha().transitiveSupertypes(s)) {
       // Most of JSR-269 is implemented on top of turbine's model, instead of the Element and
       // TypeMirror wrappers. We don't do that here because we need most of the Elements returned
@@ -209,7 +212,7 @@ public class TurbineElements implements Elements {
         switch (sym.symKind()) {
           case METHOD -> {
             TurbineExecutableElement m = (TurbineExecutableElement) el;
-            if (shouldAdd(s, from, methods, m)) {
+            if (shouldAdd(s, from, methods, results, m)) {
               methods.put(m.info().name(), m);
               results.add(el);
             }
@@ -223,13 +226,14 @@ public class TurbineElements implements Elements {
         }
       }
     }
-    return results.build();
+    return ImmutableList.copyOf(results);
   }
 
   private boolean shouldAdd(
       ClassSymbol s,
       PackageSymbol from,
       Multimap<String, TurbineExecutableElement> methods,
+      LinkedHashSet<Element> results,
       TurbineExecutableElement m) {
     if (m.sym().owner().equals(s)) {
       // always include methods (and constructors) declared in the given type
@@ -266,9 +270,11 @@ public class TurbineElements implements Elements {
       checkState(overrides.isEmpty());
       return false;
     }
-    // Add this method, and remove any methods we've already processed that it overrides.
+    // Add this method, and remove any methods we've already processed that it overrides -- from
+    // both the bookkeeping multimap and the results (a supertype's method may already be there).
     for (TurbineExecutableElement override : overrides) {
       methods.remove(name, override);
+      results.remove(override);
     }
     return true;
   }

--- a/javatests/com/google/turbine/processing/TurbineElementsGetAllMembersTest.java
+++ b/javatests/com/google/turbine/processing/TurbineElementsGetAllMembersTest.java
@@ -236,6 +236,29 @@ public class TurbineElementsGetAllMembersTest {
         "  }",
         "}",
       },
+      {
+        // A covariant override inherited through a class + interface diamond: the base-typed f()
+        // reaches Test via the superclass S, and the narrowed override via interface B. Only the
+        // override should survive in getAllMembers.
+        "=== O.java ===",
+        "interface O {}",
+        "=== P.java ===",
+        "interface P extends O {}",
+        "=== A.java ===",
+        "interface A {",
+        "  O f();",
+        "}",
+        "=== B.java ===",
+        "interface B extends A {",
+        "  @Override",
+        "  P f();",
+        "}",
+        "=== S.java ===",
+        "abstract class S implements A {}",
+        "=== Test.java ===", //
+        "abstract class Test extends S implements B {",
+        "}",
+      },
     };
     return Arrays.stream(inputs)
         .map(input -> TestInput.parse(Joiner.on('\n').join(input)))


### PR DESCRIPTION
Fixes #453.

`getAllMembers` added each supertype method to the results eagerly, and when a later-visited subtype method overrode an already-added one it removed the override only from the internal bookkeeping multimap, not from the results list. So when a supertype was visited before the subtype overriding it, the overridden (base-typed) method leaked into the returned members — diverging from `javac`.

For annotation processors this surfaces the wrong covariant return type. The motivating case: an `@Value.Immutable` (Immutables) type at a class/interface diamond generated a builder setter with the *base* parameter type, which compiled against the header jar but failed at runtime with `NoSuchMethodError`.

Fix: track results in an order-preserving `LinkedHashSet` and remove overridden methods from it as well. Added a differential test (`getAllMembers` vs `javac`) for the covariant-override diamond; it fails before this change and passes after.
